### PR TITLE
feat: always check for root and inbox dir

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/aadam-ali/second-brain-cli/config"
 	"github.com/spf13/cobra"
 )
 
@@ -11,7 +12,11 @@ var rootCmd = &cobra.Command{
 	Use:   "sb",
 	Short: "sb is second brain management tool",
 	Run: func(cmd *cobra.Command, args []string) {
+		config := config.GetConfig()
+
 		fmt.Println("Hello! Welcome to sb.")
+		fmt.Printf("Root: %s\n", config.Root)
+		fmt.Printf("Inbox: %s\n", config.Inbox)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,15 +12,16 @@ var rootCmd = &cobra.Command{
 	Use:   "sb",
 	Short: "sb is second brain management tool",
 	Run: func(cmd *cobra.Command, args []string) {
-		config := config.GetConfig()
-
 		fmt.Println("Hello! Welcome to sb.")
-		fmt.Printf("Root: %s\n", config.Root)
-		fmt.Printf("Inbox: %s\n", config.Inbox)
 	},
 }
 
 func Execute() {
+	config := config.GetConfig()
+
+	CreateDirectoryIfNotExists(config.Root)
+	CreateDirectoryIfNotExists(config.Inbox)
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"os"
+)
+
+func CreateDirectoryIfNotExists(path string) {
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(path, 0755)
+	}
+
+	if err != nil {
+		panic(err)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+type Configuration struct {
+	Root  string
+	Inbox string
+}
+
+func GetConfig() Configuration {
+	homeDir, _ := os.UserHomeDir()
+
+	root := getEnv("SB", fmt.Sprintf("%s/second-brain", homeDir))
+	inbox := fmt.Sprintf("%s/inbox", root)
+
+	return Configuration{
+		Root:  root,
+		Inbox: inbox,
+	}
+}
+
+func getEnv(key string, defaultValue string) string {
+	value, varExists := os.LookupEnv(key)
+	if varExists {
+		return value
+	}
+	return defaultValue
+}


### PR DESCRIPTION
This commit adds functionality to always check for the presence of the root and inbox directories and attempts to create them should they not exist.

To help do this, the `config` package was created. This package introduces a `Configuration` struct, and an associated `GetConfig` function which returns an instance of the `Configuration` struct. 