### PR TITLE
feat(new): add `new` command to create new notes

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aadam-ali/second-brain-cli/config"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(newCmd)
+
+	newCmd.Flags().BoolP("private", "p", false, "Mark note as private")
+}
+
+var newCmd = &cobra.Command{
+	Use:   "new [title]",
+	Short: "Create a new note",
+	Args:  cobra.MatchAll(cobra.ExactArgs(1)),
+	Run: func(cmd *cobra.Command, args []string) {
+		config := config.GetConfig()
+
+		title := args[0]
+		isPrivate, _ := cmd.Flags().GetBool("private")
+		id := time.Now().Format("20060102150405")
+
+		kebabCaseTitle := convertTitleToKebabCase(title)
+		filepath := constructNotePath(config.Inbox, id, kebabCaseTitle, isPrivate)
+		content := renderNoteContent(id, title)
+
+		createNote(filepath, content)
+	},
+}
+
+func convertTitleToKebabCase(title string) string {
+	lowercaseTitle := strings.ToLower(title)
+
+	alphanumericRegex := regexp.MustCompile(`[^a-zA-Z0-9 ]+`)
+	alphanumericTitle := alphanumericRegex.ReplaceAllString(lowercaseTitle, "")
+
+	whitespaceRegex := regexp.MustCompile(`\s+`)
+	kebabCaseTitle := whitespaceRegex.ReplaceAllString(alphanumericTitle, "-")
+
+	return kebabCaseTitle
+}
+
+func constructNotePath(inbox string, id string, kebabCaseTitle string, isPrivate bool) string {
+	extension := "md"
+	if isPrivate {
+		extension = "private.md"
+	}
+
+	return fmt.Sprintf("%s/%s-%s.%s", inbox, id, kebabCaseTitle, extension)
+}
+
+func renderNoteContent(id string, title string) string {
+	return fmt.Sprintf(`---
+id: %s
+tags: []
+---
+
+# %s
+
+Related:`, id, title)
+}
+
+func createNote(path string, content string) {
+	f, _ := os.Create(path)
+	defer f.Close()
+	_, err := f.Write([]byte(content))
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(path)
+}


### PR DESCRIPTION
This creates notes using my existing format with a slight modification.

All notes contain a unique id (timestamp based), in my current setup I only include this in the frontmatter of a note but not in the filename. I've decided to include the timestamp as the prefix of the filenames to make it easier to discern when a note was created without having to open it.

I've also added the `-p` flag to mark notes as private i.e. end with `.private.md` instead of `.md` this is so that I can have all notes in one directory instead of two seperate ones based on visibility (public and private). My personal use of this is to prevent publishing my private notes anywhere that is publicly visible.