### PR TITLE
fix(link): only remove the trailing `.md`

### DIFF
--- a/cmd/link.go
+++ b/cmd/link.go
@@ -26,7 +26,9 @@ var linkCmd = &cobra.Command{
 
 		idx, _ := fuzzyfinder.Find(files, func(i int) string { return files[i] })
 
-		fmt.Printf(" [[%s]]", strings.Trim(files[idx], ".md"))
+		filenameWithoutExt, _ := strings.CutSuffix(files[idx], ".md")
+
+		fmt.Printf(" [[%s]]", filenameWithoutExt)
 	},
 }
 


### PR DESCRIPTION
`strings.Trim` removes all leading and trailing instances of the characters specified, leading to the link command generating incorrect links for notes that start or end with 'm' or 'd'. Replacing it with `strings.CutSuffix` solves this and introduces the functionality that I intended on having.