### PR TITLE
chore(ci): add release actions and remove faulty dry_run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+on:
+  release:
+    types: [created]
+
+permissions:
+    contents: write
+    packages: write
+
+jobs:
+  releases-matrix:
+    name: Release Go Binary
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # build and publish in parallel: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64
+        goos: [linux, darwin]
+        goarch: [amd64, arm64]
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: wangyoucao577/go-release-action@7ee5ce99ec65c7a47ecc4c54eea346b394756a84
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        goversion: "https://go.dev/dl/go1.23.1.linux-amd64.tar.gz"
+        binary_name: "sb"
+        extra_files: LICENSE README.md

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,4 +19,3 @@ jobs:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
-          dry_run: true


### PR DESCRIPTION
Add an action to build and release `sb` for Linux and MacOS for both the arm64 and amd64 architectures since these are the 4 that are relevant to me.

The dry run option added previous was added to the wrong workflow in the action, however, from what is saw in the commit and from the documentation of the workflows I'm happy that it meets my needs.