### PR TITLE
fix(ci): release creation not triggering build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+name: Release binaries
 on:
   release:
     types: [created]
@@ -20,7 +21,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: wangyoucao577/go-release-action@7ee5ce99ec65c7a47ecc4c54eea346b394756a84
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.FINE_GRAINED_ACCESS_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
         goversion: "https://go.dev/dl/go1.23.1.linux-amd64.tar.gz"


### PR DESCRIPTION
GitHub prevents triggering one workflow from actions executed by another using the default `GITHUB_TOKEN`. The workaround is to use a personal access token to get around this.

<https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow>