### PR TITLE
fix(ci): add `token` key in the right place

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,5 +19,4 @@ jobs:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
-          with:
-            token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
I added an extra `with` under an existing one, this removes the extra `with` and places the `token` key in the correct place.

This is why you don't do stuff when it's nearly midnight. So many extra commits which I wouldn't have had to made if I wasn't trying to complete this before I sleep.