### PR TITLE
chore(ci): use `ldflags` over `build_flags`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,5 +25,5 @@ jobs:
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
         goversion: "https://go.dev/dl/go1.23.1.linux-amd64.tar.gz"
-        build_flags: '-ldflags "-X github.com/aadam-ali/second-brain-cli/config.version=${{ github.ref_name }}"'
+        ldflags: -X "github.com/aadam-ali/second-brain-cli/config.version=${{ github.ref_name }}"
         binary_name: "sb"


### PR DESCRIPTION
Didn't read the manual. I should have used ldflags rather than using the ldflags flag in `build_flags`.