### PR TITLE
feat(new): add command to create new note

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/aadam-ali/second-brain-cli/config"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(newCmd)
+}
+
+var newCmd = &cobra.Command{
+	Use:   "new [title]",
+	Short: "create a new note",
+	Args:  cobra.MatchAll(cobra.ExactArgs(1)),
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := config.GetConfig()
+
+		title := args[0]
+
+		filepath := constructNotePath(cfg.InboxDir, title)
+		content := renderNoteContent(title)
+
+		createNote(filepath, content)
+
+		fmt.Println(filepath)
+	},
+}
+
+func createNote(filepath string, content string) {
+	f, _ := os.Create(filepath)
+	defer f.Close()
+
+	_, err := f.Write([]byte(content))
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to create note: %s", err)
+		log.Fatal(errMsg)
+	}
+}
+
+func renderNoteContent(title string) string {
+	return fmt.Sprintf("# %s\n\n", title)
+}
+
+func constructNotePath(dir string, title string) string {
+	return fmt.Sprintf("%s/%s.md", dir, title)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+type Configuration struct {
+	RootDir  string
+	InboxDir string
+}
+
+func GetConfig() Configuration {
+	userHomeDir, _ := os.UserHomeDir()
+
+	rootDir := getEnv("SB", fmt.Sprintf("%s/SecondBrain", userHomeDir))
+	inboxDir := getEnv("SB_INBOX", fmt.Sprintf("%s/inbox", rootDir))
+
+	return Configuration{
+		RootDir:  rootDir,
+		InboxDir: inboxDir,
+	}
+}
+
+func getEnv(key string, defaultValue string) string {
+	value, varExists := os.LookupEnv(key)
+
+	if varExists == true {
+		return value
+	}
+	return defaultValue
+}


### PR DESCRIPTION
The `new` command creates a new note in the inbox directory as defined by the `RootDir` in the `config.Configuration` struct.

The root and inbox directories come with default values out of the box but can be overridden with the `SB` and `SB_INBOX` environment variables respectively.

Currently, the command will overwrite notes created with the same name if the existing note is in the inbox. This will be addressed in a future change.