### PR TITLE
feat(daily): add command to create daily note

### DIFF
--- a/cmd/daily.go
+++ b/cmd/daily.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/aadam-ali/second-brain-cli/config"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(dailyCmd)
+}
+
+var dailyCmd = &cobra.Command{
+	Use:   "daily",
+	Short: "create a daily note",
+	Args:  cobra.MatchAll(cobra.ExactArgs(0)),
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := config.GetConfig()
+
+		filepath := cfg.DailyNotePath
+
+		content := renderDailyNoteContent(cfg.Yesterday, cfg.Today, cfg.Tomorrow)
+
+		createNote(filepath, content)
+
+		fmt.Println(filepath)
+	},
+}
+
+func renderDailyNoteContent(yesterday string, today string, tomorrow string) string {
+	return fmt.Sprintf(`# %s
+
+[[%s]] - [[%s]]
+
+## Journal
+
+
+## Notes Created Today
+`, today, yesterday, tomorrow)
+}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
-	"os"
 
 	"github.com/aadam-ali/second-brain-cli/config"
 	"github.com/spf13/cobra"
@@ -23,7 +21,7 @@ var newCmd = &cobra.Command{
 		title := args[0]
 
 		filepath := constructNotePath(cfg.InboxDir, title)
-		content := renderNoteContent(title)
+		content := renderStdNoteContent(title)
 
 		createNote(filepath, content)
 
@@ -31,21 +29,6 @@ var newCmd = &cobra.Command{
 	},
 }
 
-func createNote(filepath string, content string) {
-	f, _ := os.Create(filepath)
-	defer f.Close()
-
-	_, err := f.Write([]byte(content))
-	if err != nil {
-		errMsg := fmt.Sprintf("Failed to create note: %s", err)
-		log.Fatal(errMsg)
-	}
-}
-
-func renderNoteContent(title string) string {
+func renderStdNoteContent(title string) string {
 	return fmt.Sprintf("# %s\n\n", title)
-}
-
-func constructNotePath(dir string, title string) string {
-	return fmt.Sprintf("%s/%s.md", dir, title)
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+func constructNotePath(dir string, title string) string {
+	return fmt.Sprintf("%s/%s.md", dir, title)
+}
+
+func createNote(filepath string, content string) {
+	f, _ := os.Create(filepath)
+	defer f.Close()
+
+	_, err := f.Write([]byte(content))
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to create note: %s", err)
+		log.Fatal(errMsg)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -3,11 +3,17 @@ package config
 import (
 	"fmt"
 	"os"
+	"time"
 )
 
 type Configuration struct {
-	RootDir  string
-	InboxDir string
+	RootDir       string
+	InboxDir      string
+	JournalDir    string
+	DailyNotePath string
+	Yesterday     string
+	Today         string
+	Tomorrow      string
 }
 
 func GetConfig() Configuration {
@@ -15,10 +21,21 @@ func GetConfig() Configuration {
 
 	rootDir := getEnv("SB", fmt.Sprintf("%s/SecondBrain", userHomeDir))
 	inboxDir := getEnv("SB_INBOX", fmt.Sprintf("%s/inbox", rootDir))
+	journalDir := getEnv("SB_JOURNAL", fmt.Sprintf("%s/journal", rootDir))
+
+	yesterday := time.Now().Add(-24 * time.Hour).Format("2006-01-02")
+	today := time.Now().Format("2006-01-02")
+	tomorrow := time.Now().Add(24 * time.Hour).Format("2006-01-02")
+	dailyNotePath := fmt.Sprintf("%s/%s.md", journalDir, today)
 
 	return Configuration{
-		RootDir:  rootDir,
-		InboxDir: inboxDir,
+		RootDir:       rootDir,
+		InboxDir:      inboxDir,
+		JournalDir:    journalDir,
+		DailyNotePath: dailyNotePath,
+		Yesterday:     yesterday,
+		Today:         today,
+		Tomorrow:      tomorrow,
 	}
 }
 


### PR DESCRIPTION
The `daily` command creates a daily note in the journal directory as defined by the `JournalDir` in the `config.Configuration` struct.

The journal directory comes with a default value out of the box but can be overridden with the `SB_JOURNAL` environment variable.

Currently, the command will overwrite the daily not when run more than once. This will be addressed in a future change.
