### PR TITLE
feat: don't attempt to recreate existing notes

### DIFF
--- a/cmd/daily.go
+++ b/cmd/daily.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"log"
+	"os"
 
 	"github.com/aadam-ali/second-brain-cli/config"
 	"github.com/spf13/cobra"
@@ -20,12 +22,31 @@ var dailyCmd = &cobra.Command{
 
 		filepath := cfg.DailyNotePath
 
-		content := renderDailyNoteContent(cfg.Yesterday, cfg.Today, cfg.Tomorrow)
+		dailyNoteExists := checkIfDailyNoteExists(filepath)
 
-		createNote(filepath, content)
+		if !dailyNoteExists {
+			content := renderDailyNoteContent(cfg.Yesterday, cfg.Today, cfg.Tomorrow)
+			createNote(filepath, content)
 
-		fmt.Println(filepath)
+			fmt.Println(filepath)
+		} else {
+			fmt.Printf("Note already exists: %s\n", filepath)
+		}
 	},
+}
+
+func checkIfDailyNoteExists(filepath string) bool {
+	_, err := os.Stat(filepath)
+
+	if err == nil {
+		return true
+	} else if os.IsNotExist(err) {
+		return false
+	}
+
+	log.Fatal(err)
+
+	return false
 }
 
 func renderDailyNoteContent(yesterday string, today string, tomorrow string) string {

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"io/fs"
+	"log"
+	"path/filepath"
 
 	"github.com/aadam-ali/second-brain-cli/config"
 	"github.com/spf13/cobra"
@@ -20,13 +23,38 @@ var newCmd = &cobra.Command{
 
 		title := args[0]
 
-		filepath := constructNotePath(cfg.InboxDir, title)
-		content := renderStdNoteContent(title)
+		noteExists, existingNoteFilepath := checkIfNoteExists(cfg.RootDir, title)
 
-		createNote(filepath, content)
+		if !noteExists {
+			filepath := constructNotePath(cfg.InboxDir, title)
+			content := renderStdNoteContent(title)
+			createNote(filepath, content)
 
-		fmt.Println(filepath)
+			fmt.Println(filepath)
+		} else {
+			fmt.Printf("Note already exists: %s\n", existingNoteFilepath)
+		}
 	},
+}
+
+func checkIfNoteExists(rootDir string, name string) (bool, string) {
+	pathToNote := ""
+	name = name + ".md"
+
+	err := filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, err error) error {
+		if !d.IsDir() && name == d.Name() {
+			pathToNote = path
+		}
+		return nil
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if pathToNote != "" {
+		return true, pathToNote
+	}
+	return false, ""
 }
 
 func renderStdNoteContent(title string) string {


### PR DESCRIPTION
The initial implementations of the `new` and `daily` commands were such that they would always create the note even if it already existed meaning that it would rewrite the files.

In the case of the `daily` note this was more frustrating, with the standard notes it's not as frustrating from a creation point of view since notes with the same title probably won't exist at the same time in the inbox but being able to create notes with the same title would cause issues when trying to navigate notes via backlinks.