### PR TITLE
feat(path): add command to get path of note

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -2,9 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/fs"
-	"log"
-	"path/filepath"
 
 	"github.com/aadam-ali/second-brain-cli/config"
 	"github.com/spf13/cobra"
@@ -35,26 +32,6 @@ var newCmd = &cobra.Command{
 			fmt.Printf("Note already exists: %s\n", existingNoteFilepath)
 		}
 	},
-}
-
-func checkIfNoteExists(rootDir string, name string) (bool, string) {
-	pathToNote := ""
-	name = name + ".md"
-
-	err := filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, err error) error {
-		if !d.IsDir() && name == d.Name() {
-			pathToNote = path
-		}
-		return nil
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if pathToNote != "" {
-		return true, pathToNote
-	}
-	return false, ""
 }
 
 func renderStdNoteContent(title string) string {

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/aadam-ali/second-brain-cli/config"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(pathCmd)
+}
+
+var pathCmd = &cobra.Command{
+	Use:   "path [title]",
+	Short: "outputs path of note if it exists",
+	Args:  cobra.MatchAll(cobra.ExactArgs(1)),
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := config.GetConfig()
+		title := args[0]
+
+		noteExists, filepath := checkIfNoteExists(cfg.RootDir, title)
+
+		if noteExists {
+			fmt.Println(filepath)
+		}
+	},
+}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
+	"path/filepath"
 )
 
 func constructNotePath(dir string, title string) string {
@@ -19,4 +21,24 @@ func createNote(filepath string, content string) {
 		errMsg := fmt.Sprintf("Failed to create note: %s", err)
 		log.Fatal(errMsg)
 	}
+}
+
+func checkIfNoteExists(rootDir string, name string) (bool, string) {
+	pathToNote := ""
+	name = name + ".md"
+
+	err := filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, err error) error {
+		if !d.IsDir() && name == d.Name() {
+			pathToNote = path
+		}
+		return nil
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if pathToNote != "" {
+		return true, pathToNote
+	}
+	return false, ""
 }


### PR DESCRIPTION
The `path` command will return the path of a note with a given title if it exists