### PR TITLE
chore: run `go get .`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,9 @@ module github.com/aadam-ali/second-brain-cli
 
 go 1.23.1
 
+require github.com/spf13/cobra v1.8.1
+
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )


### PR DESCRIPTION
I hadn't noticed that cobra was being pulled in as an indirect dependency, this makes sure that cobra is being added as a direct dependency.