### PR TITLE
feat(daily): append link to new note

### DIFF
--- a/cmd/daily.go
+++ b/cmd/daily.go
@@ -67,3 +67,15 @@ func renderDailyNoteContent(yesterday string, today string, tomorrow string) str
 ## Notes Created Today
 `, today, yesterday, tomorrow)
 }
+
+func appendToDailyNote(filepath string, title string) {
+	f, err := os.OpenFile(filepath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(fmt.Sprintf("\n[[%s]]", title)); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -31,6 +31,7 @@ var newCmd = &cobra.Command{
 			filepath = constructNotePath(cfg.InboxDir, title)
 			content := renderStdNoteContent(title)
 			createNote(filepath, content)
+			appendToDailyNote(cfg.DailyNotePath, title)
 
 			fmt.Println(filepath)
 		} else {


### PR DESCRIPTION
After watching the following video, I liked the idea of appending new notes to my daily notes as a way track my note creation.

<https://www.youtube.com/watch?v=B-uTTiWU9ok>

Previously, I was prefixing notes with the unique ID largely to achieve that.