### PR TITLE
feat: create daily note before appending new note link

### DIFF
--- a/cmd/daily.go
+++ b/cmd/daily.go
@@ -68,8 +68,14 @@ func renderDailyNoteContent(yesterday string, today string, tomorrow string) str
 `, today, yesterday, tomorrow)
 }
 
-func appendToDailyNote(filepath string, title string) {
-	f, err := os.OpenFile(filepath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+func appendToDailyNote(cfg config.Configuration, title string) {
+	if !checkIfDailyNoteExists(cfg.DailyNotePath) {
+		content := renderDailyNoteContent(cfg.Yesterday, cfg.Today, cfg.Tomorrow)
+		createNote(cfg.DailyNotePath, content)
+		fmt.Printf("Daily note not found; creating a new one: %s\n", cfg.DailyNotePath)
+	}
+
+	f, err := os.OpenFile(cfg.DailyNotePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -34,7 +34,7 @@ var newCmd = &cobra.Command{
 			filepath = constructNotePath(cfg.InboxDir, kebabCaseTitle)
 			content := renderStdNoteContent(title)
 			createNote(filepath, content)
-			appendToDailyNote(cfg.DailyNotePath, kebabCaseTitle)
+			appendToDailyNote(cfg, kebabCaseTitle)
 
 			fmt.Println(filepath)
 		} else {


### PR DESCRIPTION
**What?**

If missing, create the daily note before appending a backlink to a new note to it.

**Why?**

It's possible that a new (non-daily) note is created before the daily note, in this scenario the backlink to the new note is appended to an empty file. This means that the daily note is created without it's template.

By making this change, the two code paths that lead to the daily note being created will do so with it's template.