### PR TITLE
fix(path): search using kebab cased title

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"regexp"
-	"strings"
 
 	"github.com/aadam-ali/second-brain-cli/config"
 	"github.com/spf13/cobra"
@@ -46,15 +44,6 @@ var newCmd = &cobra.Command{
 			openFileInVim(cfg.RootDir, filepath)
 		}
 	},
-}
-
-func titleToKebabCase(title string) string {
-	title = strings.ToLower(title)
-
-	title = regexp.MustCompile(`[^a-z0-9]+`).ReplaceAllString(title, "-")
-	title = regexp.MustCompile(`^-+|-+$`).ReplaceAllString(title, "")
-
-	return title
 }
 
 func renderStdNoteContent(title string) string {

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -19,6 +19,8 @@ var pathCmd = &cobra.Command{
 		cfg := config.GetConfig()
 		title := args[0]
 
+		title = titleToKebabCase(title)
+
 		noteExists, filepath := checkIfNoteExists(cfg.RootDir, title)
 
 		if noteExists {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strings"
 )
 
 func constructNotePath(dir string, title string) string {
@@ -54,4 +56,13 @@ func openFileInVim(rootDir string, filepath string) {
 	if err != nil {
 		fmt.Println(err)
 	}
+}
+
+func titleToKebabCase(title string) string {
+	title = strings.ToLower(title)
+
+	title = regexp.MustCompile(`[^a-z0-9]+`).ReplaceAllString(title, "-")
+	title = regexp.MustCompile(`^-+|-+$`).ReplaceAllString(title, "")
+
+	return title
 }


### PR DESCRIPTION
**What?**

Search for file paths using their kebab cased title.

**Why?**

After release `0.3.0`, all files are now created with a kebab cased title. However, the `path` command still expects the filename to be the raw title. This commit fixes the previous assumption by searching using the kebab cased title.