### PR TITLE
chore(pre-commit): Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+  - repo: https://github.com/TekWizely/pre-commit-golang
+    rev: v0.8.3
+    hooks:
+      - id: go-imports

--- a/cmd/daily.go
+++ b/cmd/daily.go
@@ -22,7 +22,7 @@ var dailyCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := config.GetConfig()
 
-		no_open, _ := cmd.Flags().GetBool("no-open")
+		noOpen, _ := cmd.Flags().GetBool("no-open")
 		filepath := cfg.DailyNotePath
 
 		dailyNoteExists := checkIfDailyNoteExists(filepath)
@@ -36,7 +36,7 @@ var dailyCmd = &cobra.Command{
 			fmt.Printf("Note already exists: %s\n", filepath)
 		}
 
-		if no_open == false {
+		if !noOpen {
 			openFileInVim(cfg.RootDir, cfg.DailyNotePath)
 		}
 	},

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -20,7 +20,7 @@ var newCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := config.GetConfig()
 
-		no_open, _ := cmd.Flags().GetBool("no-open")
+		noOpen, _ := cmd.Flags().GetBool("no-open")
 		var filepath string
 
 		title := args[0]
@@ -40,7 +40,7 @@ var newCmd = &cobra.Command{
 			fmt.Printf("Note already exists: %s\n", filepath)
 		}
 
-		if no_open == false {
+		if !noOpen {
 			openFileInVim(cfg.RootDir, filepath)
 		}
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,8 @@ var rootCmd = &cobra.Command{
 	},
 }
 
+// Execute handles the execution of the provided command
+// this may be the root command or any of it's children
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 
 var version string = "development"
 
+// Configuration holds the configuration settings for the CLI
 type Configuration struct {
 	RootDir       string
 	InboxDir      string
@@ -19,6 +20,8 @@ type Configuration struct {
 	Version       string
 }
 
+// GetConfig returns the Conifugration struct by reading environment
+// variables and calculating values at runtime
 func GetConfig() Configuration {
 	userHomeDir, _ := os.UserHomeDir()
 
@@ -46,7 +49,7 @@ func GetConfig() Configuration {
 func getEnv(key string, defaultValue string) string {
 	value, varExists := os.LookupEnv(key)
 
-	if varExists == true {
+	if varExists {
 		return value
 	}
 	return defaultValue


### PR DESCRIPTION
This is a pretty simple configuration. The golang hooks, do provide a testing hook, though due to the current lack of tests I have opted to omit them for now.

I am also aware that the version of <https://github.com/TekWizely/pre-commit-golang> is ~4 years old, however, the alternative was <https://github.com/dnephin/pre-commit-golang> which was last committed to ~3 years ago and is now archived, whilst a v1.0.0 is being worked on for the current option.

I was initially planning on include a linting hook, however, the `golangci-lint` hooks provided don't seem to work for me. For now I'll continue running this manually.

Additionally, I have applied fixes for the lint errors returned by:

  - `golint ./...`
  - `golangci-lint run`

These changes do not impact the behaviour of the code.