### PR TITLE
chore: Add tests for `config` package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 )
 
 var version string = "development"
+var now = time.Now
 
 // Configuration holds the configuration settings for the CLI
 type Configuration struct {
@@ -29,9 +30,9 @@ func GetConfig() Configuration {
 	inboxDir := getEnv("SB_INBOX", fmt.Sprintf("%s/inbox", rootDir))
 	journalDir := getEnv("SB_JOURNAL", fmt.Sprintf("%s/journal", rootDir))
 
-	yesterday := time.Now().Add(-24 * time.Hour).Format("2006-01-02")
-	today := time.Now().Format("2006-01-02")
-	tomorrow := time.Now().Add(24 * time.Hour).Format("2006-01-02")
+	yesterday := now().Add(-24 * time.Hour).Format("2006-01-02")
+	today := now().Format("2006-01-02")
+	tomorrow := now().Add(24 * time.Hour).Format("2006-01-02")
 	dailyNotePath := fmt.Sprintf("%s/%s.md", journalDir, today)
 
 	return Configuration{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestGetEnvExists(t *testing.T) {
+	want := "CustomValue"
+
+	os.Setenv("SB_TEST_VAR", want)
+
+	got := getEnv("SB_TEST_VAR", "default")
+
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestGetEnvDoesNotExist(t *testing.T) {
+	want := "DefaultValue"
+
+	os.Unsetenv("SB_TEST_VAR")
+
+	got := getEnv("SB_TEST_VAR", want)
+
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestGetConfigDefaultValues(t *testing.T) {
+	now = func() time.Time {
+		return time.Date(2025, 7, 13, 20, 0, 0, 0, time.UTC)
+	}
+
+	os.Clearenv()
+	os.Setenv("HOME", "/home/test")
+	rootDir := "/home/test/SecondBrain"
+
+	want := Configuration{
+		RootDir:       rootDir,
+		InboxDir:      rootDir + "/inbox",
+		JournalDir:    rootDir + "/journal",
+		DailyNotePath: rootDir + "/journal/2025-07-13.md",
+		Yesterday:     "2025-07-12",
+		Today:         "2025-07-13",
+		Tomorrow:      "2025-07-14",
+		Version:       "development",
+	}
+	got := GetConfig()
+
+	if got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestGetConfigOverriddenValues(t *testing.T) {
+	now = func() time.Time {
+		return time.Date(2025, 7, 13, 20, 0, 0, 0, time.UTC)
+	}
+
+	sb := "/home/test/Documents/Notes"
+	sbJournal := "/home/test/Documents/Notes/Log"
+	sbInbox := "/home/test/Documents/Notes/Entrypoint"
+
+	os.Clearenv()
+	os.Setenv("HOME", "/home/test")
+	os.Setenv("SB", sb)
+	os.Setenv("SB_JOURNAL", sbJournal)
+	os.Setenv("SB_INBOX", sbInbox)
+
+	want := Configuration{
+		RootDir:       sb,
+		InboxDir:      sbInbox,
+		JournalDir:    sbJournal,
+		DailyNotePath: sbJournal + "/2025-07-13.md",
+		Yesterday:     "2025-07-12",
+		Today:         "2025-07-13",
+		Tomorrow:      "2025-07-14",
+		Version:       "development",
+	}
+
+	got := GetConfig()
+
+	if got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -28,7 +28,7 @@ func TestTitleToKebabCase(t *testing.T) {
 		got := TitleToKebabCase(tt.input)
 
 		if got != tt.want {
-			t.Errorf("got '%s', want '%s'", got, tt.want)
+			t.Errorf("got %q, want %q", got, tt.want)
 		}
 
 	}
@@ -48,7 +48,7 @@ func TestConstructNotePath(t *testing.T) {
 		got := ConstructNotePath(tt.path, tt.title)
 
 		if got != tt.want {
-			t.Errorf("got '%s', want '%s'", got, tt.want)
+			t.Errorf("got %q, want %q", got, tt.want)
 		}
 
 	}
@@ -79,7 +79,7 @@ Some content
 		os.RemoveAll(path)
 
 		if string(got) != tt.content {
-			t.Errorf("got '%s', want '%s'", got, tt.content)
+			t.Errorf("got %q, want %q", got, tt.content)
 		}
 
 	}


### PR DESCRIPTION
Credit to <https://ekm.id.au/posts/golang-mock-time/> for the approach to mocking `time.Now`.

I've also replaced `'%s'` with `%q` in formatted strings, this gives quotes around the templated values for free.