### PR TITLE
chore: Retrofit integration tests

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -177,3 +177,50 @@ func TestDailyCmdAlreadyExists(t *testing.T) {
 		t.Errorf("expected %q to exist", wantOutputFilepath)
 	}
 }
+
+func TestPathCmdExists(t *testing.T) {
+	sb := prepareEnvironment()
+	defer os.RemoveAll(sb)
+
+	var wantError error
+	wantOutputFilepath := filepath.Join(sb, "inbox/hello-world.md")
+	os.Create(wantOutputFilepath)
+
+	gotOutput, gotError := captureStdout(pathCmdFunction, pathCmd, []string{"hello-world"})
+
+	if gotError != wantError {
+		t.Errorf("got %q, want %q", gotError, wantError)
+	}
+
+	if !strings.Contains(gotOutput, wantOutputFilepath) {
+		t.Errorf("expected to find %q in %q", wantOutputFilepath, gotOutput)
+	}
+
+	_, statErr := os.Stat(wantOutputFilepath)
+	if statErr != nil {
+		t.Errorf("expected %q to exist", wantOutputFilepath)
+	}
+}
+
+func TestPathCmdDoesNotExist(t *testing.T) {
+	sb := prepareEnvironment()
+	defer os.RemoveAll(sb)
+
+	var wantError error
+	wantOutputFilepath := filepath.Join(sb, "somefolder/hello-world.md")
+
+	gotOutput, gotError := captureStdout(pathCmdFunction, pathCmd, []string{"hello-world"})
+
+	if gotError != wantError {
+		t.Errorf("got %q, want %q", gotError, wantError)
+	}
+
+	if strings.Contains(gotOutput, wantOutputFilepath) {
+		t.Errorf("expected to not find %q in %q", wantOutputFilepath, gotOutput)
+	}
+
+	_, statErr := os.Stat(wantOutputFilepath)
+	if statErr == nil {
+		t.Errorf("expected %q not to exist", wantOutputFilepath)
+	}
+}

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -121,6 +121,59 @@ func TestNewCmdCreateDailyNote(t *testing.T) {
 
 	_, dailyNoteErr := os.Stat(fmt.Sprintf("%s/journal/2025-07-13.md", sb))
 	if dailyNoteErr != nil {
-		t.Errorf("expected %q exist", wantOutputFilepath)
+		t.Errorf("expected %q to exist", wantOutputFilepath)
+	}
+}
+
+func TestDailyCmd(t *testing.T) {
+	config.Now = func() time.Time {
+		return time.Date(2025, 7, 13, 20, 0, 0, 0, time.UTC)
+	}
+
+	sb := prepareEnvironment()
+	defer os.RemoveAll(sb)
+
+	var wantError error
+	wantOutputFilepath := filepath.Join(sb, "journal/2025-07-13.md")
+	dailyCmd.Flags().Set("no-open", "true")
+	_, gotError := captureStdout(dailyCmdFunction, dailyCmd, []string{})
+
+	if gotError != wantError {
+		t.Errorf("got %q, want %q", gotError, wantError)
+	}
+
+	_, dailyNoteErr := os.Stat(fmt.Sprintf("%s/journal/2025-07-13.md", sb))
+	if dailyNoteErr != nil {
+		t.Errorf("expected %q to exist", wantOutputFilepath)
+	}
+}
+
+func TestDailyCmdAlreadyExists(t *testing.T) {
+	config.Now = func() time.Time {
+		return time.Date(2025, 7, 13, 20, 0, 0, 0, time.UTC)
+	}
+
+	sb := prepareEnvironment()
+	defer os.RemoveAll(sb)
+
+	var wantError error
+	wantOutputFilepath := filepath.Join(sb, "journal/2025-07-13.md")
+	wantOutput := fmt.Sprintf("Note already exists: %s", wantOutputFilepath)
+	os.Create(wantOutputFilepath)
+
+	dailyCmd.Flags().Set("no-open", "true")
+	gotOutput, gotError := captureStdout(dailyCmdFunction, dailyCmd, []string{})
+
+	if gotError != wantError {
+		t.Errorf("got %q, want %q", gotError, wantError)
+	}
+
+	if !strings.Contains(gotOutput, wantOutput) {
+		t.Errorf("expected to find %q in %q", wantOutputFilepath, gotOutput)
+	}
+
+	_, dailyNoteErr := os.Stat(fmt.Sprintf("%s/journal/2025-07-13.md", sb))
+	if dailyNoteErr != nil {
+		t.Errorf("expected %q to exist", wantOutputFilepath)
 	}
 }

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -1,7 +1,14 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/aadam-ali/second-brain-cli/config"
 )
 
 func TestVersionCmd(t *testing.T) {
@@ -16,5 +23,104 @@ func TestVersionCmd(t *testing.T) {
 
 	if gotOutput != wantOutput {
 		t.Errorf("got %q, want %q", gotOutput, wantOutput)
+	}
+}
+
+func TestNewCmd(t *testing.T) {
+	config.Now = func() time.Time {
+		return time.Date(2025, 7, 13, 20, 0, 0, 0, time.UTC)
+	}
+
+	sb := prepareEnvironment()
+	defer os.RemoveAll(sb)
+
+	os.Create(filepath.Join(sb, "journal/2025-07-13.md"))
+
+	var wantError error
+	wantOutputFilepath := filepath.Join(sb, "inbox/hello-world.md")
+	dontWantOutputDailyNote := fmt.Sprintf("Daily note not found; creating a new one: %s/journal/2025-07-13.md", sb)
+
+	newCmd.Flags().Set("no-open", "true")
+	gotOutput, gotError := captureStdout(newCmdFunction, newCmd, []string{"Hello World"})
+
+	if gotError != wantError {
+		t.Errorf("got %q, want %q", gotError, wantError)
+	}
+
+	if !strings.Contains(gotOutput, wantOutputFilepath) {
+		t.Errorf("expected to find %q in %q", wantOutputFilepath, gotOutput)
+	}
+
+	if strings.Contains(gotOutput, dontWantOutputDailyNote) {
+		t.Errorf("expected to not find %q in %q", dontWantOutputDailyNote, gotOutput)
+	}
+
+	_, newNoteErr := os.Stat(wantOutputFilepath)
+	if newNoteErr != nil {
+		t.Errorf("expected %q exist", wantOutputFilepath)
+	}
+}
+
+func TestNewCmdExistingNote(t *testing.T) {
+	sb := prepareEnvironment()
+	defer os.RemoveAll(sb)
+
+	var wantError error
+	wantOutputFilepath := filepath.Join(sb, "inbox/hello-world.md")
+	os.Create(wantOutputFilepath)
+	wantOutput := fmt.Sprintf("Note already exists: %s", wantOutputFilepath)
+
+	newCmd.Flags().Set("no-open", "true")
+	gotOutput, gotError := captureStdout(newCmdFunction, newCmd, []string{"Hello World"})
+
+	if gotError != wantError {
+		t.Errorf("got %q, want %q", gotError, wantError)
+	}
+
+	if !strings.Contains(gotOutput, wantOutput) {
+		t.Errorf("expected to find %q in %q", wantOutput, gotOutput)
+	}
+
+	_, newNoteErr := os.Stat(wantOutputFilepath)
+	if newNoteErr != nil {
+		t.Errorf("expected %q exist", wantOutputFilepath)
+	}
+}
+
+func TestNewCmdCreateDailyNote(t *testing.T) {
+	config.Now = func() time.Time {
+		return time.Date(2025, 7, 13, 20, 0, 0, 0, time.UTC)
+	}
+
+	sb := prepareEnvironment()
+	defer os.RemoveAll(sb)
+
+	var wantError error
+	wantOutputFilepath := filepath.Join(sb, "inbox/hello-world.md")
+	wantOutputDailyNote := fmt.Sprintf("Daily note not found; creating a new one: %s/journal/2025-07-13.md", sb)
+
+	newCmd.Flags().Set("no-open", "true")
+	gotOutput, gotError := captureStdout(newCmdFunction, newCmd, []string{"Hello World"})
+
+	if gotError != wantError {
+		t.Errorf("got %q, want %q", gotError, wantError)
+	}
+
+	if !strings.Contains(gotOutput, wantOutputFilepath) {
+		t.Errorf("expected to find %q in %q", wantOutputFilepath, gotOutput)
+	}
+
+	if !strings.Contains(gotOutput, wantOutputDailyNote) {
+		t.Errorf("expected to find %q in %q", wantOutputDailyNote, gotOutput)
+	}
+
+	_, newNoteErr := os.Stat(wantOutputFilepath)
+	if newNoteErr != nil {
+		t.Errorf("expected %q exist", wantOutputFilepath)
+	}
+
+	_, dailyNoteErr := os.Stat(fmt.Sprintf("%s/journal/2025-07-13.md", sb))
+	if dailyNoteErr != nil {
+		t.Errorf("expected %q exist", wantOutputFilepath)
 	}
 }

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestVersionCmd(t *testing.T) {
+	var wantError error
+	wantOutput := "sb development\n"
+
+	gotOutput, gotError := captureStdout(versionCmdFunction, versionCmd, []string{})
+
+	if gotError != wantError {
+		t.Errorf("got %q, want %q", gotError, wantError)
+	}
+
+	if gotOutput != wantOutput {
+		t.Errorf("got %q, want %q", gotOutput, wantOutput)
+	}
+}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -14,38 +14,41 @@ func init() {
 	newCmd.Flags().BoolP("no-open", "n", false, "prevents opening of file in editor")
 }
 
+func newCmdFunction(cmd *cobra.Command, args []string) error {
+	cfg := config.GetConfig()
+
+	noOpen, _ := cmd.Flags().GetBool("no-open")
+	var filepath string
+	title := args[0]
+
+	kebabCaseTitle := internal.TitleToKebabCase(title)
+
+	noteExists, existingNoteFilepath := internal.CheckIfNoteExists(cfg.RootDir, kebabCaseTitle)
+
+	if !noteExists {
+		filepath = internal.ConstructNotePath(cfg.InboxDir, kebabCaseTitle)
+		content := renderStdNoteContent(title)
+		internal.CreateNote(filepath, content)
+		appendToDailyNote(cfg, kebabCaseTitle)
+
+		fmt.Println(filepath)
+	} else {
+		filepath = existingNoteFilepath
+		fmt.Printf("Note already exists: %s\n", filepath)
+	}
+
+	if !noOpen {
+		internal.OpenFileInVim(cfg.RootDir, filepath)
+	}
+
+	return nil
+}
+
 var newCmd = &cobra.Command{
 	Use:   "new [title]",
 	Short: "create a new note",
 	Args:  cobra.MatchAll(cobra.ExactArgs(1)),
-	Run: func(cmd *cobra.Command, args []string) {
-		cfg := config.GetConfig()
-
-		noOpen, _ := cmd.Flags().GetBool("no-open")
-		var filepath string
-
-		title := args[0]
-		kebabCaseTitle := internal.TitleToKebabCase(title)
-
-		noteExists, existingNoteFilepath := internal.CheckIfNoteExists(cfg.RootDir, kebabCaseTitle)
-
-		if !noteExists {
-			filepath = internal.ConstructNotePath(cfg.InboxDir, kebabCaseTitle)
-			content := renderStdNoteContent(title)
-			internal.CreateNote(filepath, content)
-			appendToDailyNote(cfg, kebabCaseTitle)
-
-			fmt.Println(filepath)
-		} else {
-			filepath = existingNoteFilepath
-			fmt.Printf("Note already exists: %s\n", filepath)
-		}
-
-		if !noOpen {
-			internal.OpenFileInVim(cfg.RootDir, filepath)
-		}
-	},
-}
+	RunE:  newCmdFunction}
 
 func renderStdNoteContent(title string) string {
 	return fmt.Sprintf("# %s\n\n", title)

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -12,20 +12,24 @@ func init() {
 	rootCmd.AddCommand(pathCmd)
 }
 
+func pathCmdFunction(cmd *cobra.Command, args []string) error {
+	cfg := config.GetConfig()
+	title := args[0]
+
+	title = internal.TitleToKebabCase(title)
+
+	noteExists, filepath := internal.CheckIfNoteExists(cfg.RootDir, title)
+
+	if noteExists {
+		fmt.Println(filepath)
+	}
+
+	return nil
+}
+
 var pathCmd = &cobra.Command{
 	Use:   "path [title]",
 	Short: "outputs path of note if it exists",
 	Args:  cobra.MatchAll(cobra.ExactArgs(1)),
-	Run: func(cmd *cobra.Command, args []string) {
-		cfg := config.GetConfig()
-		title := args[0]
-
-		title = internal.TitleToKebabCase(title)
-
-		noteExists, filepath := internal.CheckIfNoteExists(cfg.RootDir, title)
-
-		if noteExists {
-			fmt.Println(filepath)
-		}
-	},
+	RunE:  pathCmdFunction,
 }

--- a/cmd/test_helpers_test.go
+++ b/cmd/test_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
@@ -22,4 +23,15 @@ func captureStdout(fn func(cmd *cobra.Command, args []string) error, cmd *cobra.
 	io.Copy(&buf, r)
 
 	return buf.String(), err
+}
+
+func prepareEnvironment() string {
+	sb, _ := os.MkdirTemp("", "second-brain-cli-")
+	os.Mkdir(filepath.Join(sb, "inbox"), 0700)
+	os.Mkdir(filepath.Join(sb, "journal"), 0700)
+
+	os.Clearenv()
+	os.Setenv("SB", sb)
+
+	return sb
 }

--- a/cmd/test_helpers_test.go
+++ b/cmd/test_helpers_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func captureStdout(fn func(cmd *cobra.Command, args []string) error, cmd *cobra.Command, args []string) (string, error) {
+	originalStdout := os.Stdout
+
+	var buf bytes.Buffer
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := fn(cmd, args)
+
+	w.Close()
+	os.Stdout = originalStdout
+	io.Copy(&buf, r)
+
+	return buf.String(), err
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,13 +11,17 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 }
 
+func versionCmdFunction(cmd *cobra.Command, args []string) error {
+	cfg := config.GetConfig()
+
+	fmt.Printf("sb %s\n", cfg.Version)
+
+	return nil
+}
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "outputs version of sb",
 	Args:  cobra.MatchAll(cobra.ExactArgs(0)),
-	Run: func(cmd *cobra.Command, args []string) {
-		cfg := config.GetConfig()
-
-		fmt.Printf("sb %s\n", cfg.Version)
-	},
+	RunE:  versionCmdFunction,
 }

--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 var version string = "development"
-var now = time.Now
+var Now = time.Now
 
 // Configuration holds the configuration settings for the CLI
 type Configuration struct {
@@ -30,9 +30,9 @@ func GetConfig() Configuration {
 	inboxDir := getEnv("SB_INBOX", fmt.Sprintf("%s/inbox", rootDir))
 	journalDir := getEnv("SB_JOURNAL", fmt.Sprintf("%s/journal", rootDir))
 
-	yesterday := now().Add(-24 * time.Hour).Format("2006-01-02")
-	today := now().Format("2006-01-02")
-	tomorrow := now().Add(24 * time.Hour).Format("2006-01-02")
+	yesterday := Now().Add(-24 * time.Hour).Format("2006-01-02")
+	today := Now().Format("2006-01-02")
+	tomorrow := Now().Add(24 * time.Hour).Format("2006-01-02")
 	dailyNotePath := fmt.Sprintf("%s/%s.md", journalDir, today)
 
 	return Configuration{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,7 +31,7 @@ func TestGetEnvDoesNotExist(t *testing.T) {
 }
 
 func TestGetConfigDefaultValues(t *testing.T) {
-	now = func() time.Time {
+	Now = func() time.Time {
 		return time.Date(2025, 7, 13, 20, 0, 0, 0, time.UTC)
 	}
 
@@ -57,7 +57,7 @@ func TestGetConfigDefaultValues(t *testing.T) {
 }
 
 func TestGetConfigOverriddenValues(t *testing.T) {
-	now = func() time.Time {
+	Now = func() time.Time {
 		return time.Date(2025, 7, 13, 20, 0, 0, 0, time.UTC)
 	}
 


### PR DESCRIPTION
This PR retrofits integration tests for the existing commands.

Whilst the aim was to retain the existing functionality whilst adding the tests, there has been some refactoring, including a move from `Run` to `RunE`, though at the moment all the functions return `nil`.

The other change, was moving from anonymous functions to defined functions to make the code more testable.