### PR TITLE
feat: Return useful error messages and code

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -15,14 +15,14 @@ func TestVersionCmd(t *testing.T) {
 	var wantError error
 	wantOutput := "sb development\n"
 
-	gotOutput, gotError := captureStdout(versionCmdFunction, versionCmd, []string{})
+	gotStdout, _, gotError := captureOutput(versionCmdFunction, versionCmd, []string{})
 
 	if gotError != wantError {
 		t.Errorf("got %q, want %q", gotError, wantError)
 	}
 
-	if gotOutput != wantOutput {
-		t.Errorf("got %q, want %q", gotOutput, wantOutput)
+	if gotStdout != wantOutput {
+		t.Errorf("got %q, want %q", gotStdout, wantOutput)
 	}
 }
 
@@ -41,18 +41,18 @@ func TestNewCmd(t *testing.T) {
 	dontWantOutputDailyNote := fmt.Sprintf("Daily note not found; creating a new one: %s/journal/2025-07-13.md", sb)
 
 	newCmd.Flags().Set("no-open", "true")
-	gotOutput, gotError := captureStdout(newCmdFunction, newCmd, []string{"Hello World"})
+	gotStdout, _, gotError := captureOutput(newCmdFunction, newCmd, []string{"Hello World"})
 
 	if gotError != wantError {
 		t.Errorf("got %q, want %q", gotError, wantError)
 	}
 
-	if !strings.Contains(gotOutput, wantOutputFilepath) {
-		t.Errorf("expected to find %q in %q", wantOutputFilepath, gotOutput)
+	if !strings.Contains(gotStdout, wantOutputFilepath) {
+		t.Errorf("expected to find %q in %q", wantOutputFilepath, gotStdout)
 	}
 
-	if strings.Contains(gotOutput, dontWantOutputDailyNote) {
-		t.Errorf("expected to not find %q in %q", dontWantOutputDailyNote, gotOutput)
+	if strings.Contains(gotStdout, dontWantOutputDailyNote) {
+		t.Errorf("expected to not find %q in %q", dontWantOutputDailyNote, gotStdout)
 	}
 
 	_, newNoteErr := os.Stat(wantOutputFilepath)
@@ -65,20 +65,20 @@ func TestNewCmdExistingNote(t *testing.T) {
 	sb := prepareEnvironment()
 	defer os.RemoveAll(sb)
 
-	var wantError error
 	wantOutputFilepath := filepath.Join(sb, "inbox/hello-world.md")
+	wantOutput := fmt.Sprintf("Note with title \"hello-world\" already exists at %s", wantOutputFilepath)
+
 	os.Create(wantOutputFilepath)
-	wantOutput := fmt.Sprintf("Note already exists: %s", wantOutputFilepath)
 
 	newCmd.Flags().Set("no-open", "true")
-	gotOutput, gotError := captureStdout(newCmdFunction, newCmd, []string{"Hello World"})
+	_, gotStderr, gotError := captureOutput(newCmdFunction, newCmd, []string{"Hello World"})
 
-	if gotError != wantError {
-		t.Errorf("got %q, want %q", gotError, wantError)
+	if gotError.Error() != wantOutput {
+		t.Errorf("got %q, want %q", gotError, wantOutput)
 	}
 
-	if !strings.Contains(gotOutput, wantOutput) {
-		t.Errorf("expected to find %q in %q", wantOutput, gotOutput)
+	if !strings.Contains(gotStderr, wantOutput) {
+		t.Errorf("expected to find %q in %q", wantOutput, gotStderr)
 	}
 
 	_, newNoteErr := os.Stat(wantOutputFilepath)
@@ -100,18 +100,18 @@ func TestNewCmdCreateDailyNote(t *testing.T) {
 	wantOutputDailyNote := fmt.Sprintf("Daily note not found; creating a new one: %s/journal/2025-07-13.md", sb)
 
 	newCmd.Flags().Set("no-open", "true")
-	gotOutput, gotError := captureStdout(newCmdFunction, newCmd, []string{"Hello World"})
+	gotStdout, _, gotError := captureOutput(newCmdFunction, newCmd, []string{"Hello World"})
 
 	if gotError != wantError {
 		t.Errorf("got %q, want %q", gotError, wantError)
 	}
 
-	if !strings.Contains(gotOutput, wantOutputFilepath) {
-		t.Errorf("expected to find %q in %q", wantOutputFilepath, gotOutput)
+	if !strings.Contains(gotStdout, wantOutputFilepath) {
+		t.Errorf("expected to find %q in %q", wantOutputFilepath, gotStdout)
 	}
 
-	if !strings.Contains(gotOutput, wantOutputDailyNote) {
-		t.Errorf("expected to find %q in %q", wantOutputDailyNote, gotOutput)
+	if !strings.Contains(gotStdout, wantOutputDailyNote) {
+		t.Errorf("expected to find %q in %q", wantOutputDailyNote, gotStdout)
 	}
 
 	_, newNoteErr := os.Stat(wantOutputFilepath)
@@ -136,7 +136,7 @@ func TestDailyCmd(t *testing.T) {
 	var wantError error
 	wantOutputFilepath := filepath.Join(sb, "journal/2025-07-13.md")
 	dailyCmd.Flags().Set("no-open", "true")
-	_, gotError := captureStdout(dailyCmdFunction, dailyCmd, []string{})
+	_, _, gotError := captureOutput(dailyCmdFunction, dailyCmd, []string{})
 
 	if gotError != wantError {
 		t.Errorf("got %q, want %q", gotError, wantError)
@@ -158,18 +158,17 @@ func TestDailyCmdAlreadyExists(t *testing.T) {
 
 	var wantError error
 	wantOutputFilepath := filepath.Join(sb, "journal/2025-07-13.md")
-	wantOutput := fmt.Sprintf("Note already exists: %s", wantOutputFilepath)
 	os.Create(wantOutputFilepath)
 
 	dailyCmd.Flags().Set("no-open", "true")
-	gotOutput, gotError := captureStdout(dailyCmdFunction, dailyCmd, []string{})
+	gotStdout, _, gotError := captureOutput(dailyCmdFunction, dailyCmd, []string{})
 
 	if gotError != wantError {
 		t.Errorf("got %q, want %q", gotError, wantError)
 	}
 
-	if !strings.Contains(gotOutput, wantOutput) {
-		t.Errorf("expected to find %q in %q", wantOutputFilepath, gotOutput)
+	if !strings.Contains(gotStdout, wantOutputFilepath) {
+		t.Errorf("expected to find %q in %q", wantOutputFilepath, gotStdout)
 	}
 
 	_, dailyNoteErr := os.Stat(fmt.Sprintf("%s/journal/2025-07-13.md", sb))
@@ -186,14 +185,14 @@ func TestPathCmdExists(t *testing.T) {
 	wantOutputFilepath := filepath.Join(sb, "inbox/hello-world.md")
 	os.Create(wantOutputFilepath)
 
-	gotOutput, gotError := captureStdout(pathCmdFunction, pathCmd, []string{"hello-world"})
+	gotStdout, _, gotError := captureOutput(pathCmdFunction, pathCmd, []string{"hello-world"})
 
 	if gotError != wantError {
 		t.Errorf("got %q, want %q", gotError, wantError)
 	}
 
-	if !strings.Contains(gotOutput, wantOutputFilepath) {
-		t.Errorf("expected to find %q in %q", wantOutputFilepath, gotOutput)
+	if !strings.Contains(gotStdout, wantOutputFilepath) {
+		t.Errorf("expected to find %q in %q", wantOutputFilepath, gotStdout)
 	}
 
 	_, statErr := os.Stat(wantOutputFilepath)
@@ -206,17 +205,17 @@ func TestPathCmdDoesNotExist(t *testing.T) {
 	sb := prepareEnvironment()
 	defer os.RemoveAll(sb)
 
-	var wantError error
 	wantOutputFilepath := filepath.Join(sb, "somefolder/hello-world.md")
+	wantStderr := "Note with title \"hello-world\" (hello-world) does not exist"
 
-	gotOutput, gotError := captureStdout(pathCmdFunction, pathCmd, []string{"hello-world"})
+	_, gotStderr, gotError := captureOutput(pathCmdFunction, pathCmd, []string{"hello-world"})
 
-	if gotError != wantError {
-		t.Errorf("got %q, want %q", gotError, wantError)
+	if gotError.Error() != wantStderr {
+		t.Errorf("got %q, want %q", gotError, wantStderr)
 	}
 
-	if strings.Contains(gotOutput, wantOutputFilepath) {
-		t.Errorf("expected to not find %q in %q", wantOutputFilepath, gotOutput)
+	if !strings.Contains(gotStderr, wantStderr) {
+		t.Errorf("expected to not find %q in %q", wantStderr, gotStderr)
 	}
 
 	_, statErr := os.Stat(wantOutputFilepath)

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/aadam-ali/second-brain-cli/config"
 	"github.com/aadam-ali/second-brain-cli/internal"
@@ -33,8 +35,9 @@ func newCmdFunction(cmd *cobra.Command, args []string) error {
 
 		fmt.Println(filepath)
 	} else {
-		filepath = existingNoteFilepath
-		fmt.Printf("Note already exists: %s\n", filepath)
+		error := fmt.Sprintf("Note with title %q already exists at %s", kebabCaseTitle, existingNoteFilepath)
+		fmt.Fprintln(os.Stderr, error)
+		return errors.New(error)
 	}
 
 	if !noOpen {

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/aadam-ali/second-brain-cli/config"
 	"github.com/aadam-ali/second-brain-cli/internal"
@@ -20,10 +22,13 @@ func pathCmdFunction(cmd *cobra.Command, args []string) error {
 
 	noteExists, filepath := internal.CheckIfNoteExists(cfg.RootDir, title)
 
-	if noteExists {
-		fmt.Println(filepath)
+	if !noteExists {
+		error := fmt.Sprintf("Note with title %q (%s) does not exist", args[0], title)
+		fmt.Fprintln(os.Stderr, error)
+		return errors.New(error)
 	}
 
+	fmt.Println(filepath)
 	return nil
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
 	"os"
 
@@ -11,6 +10,10 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "sb",
 	Short: "sb is a note taking management tool",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		err := cmd.Help()
 
@@ -24,7 +27,6 @@ var rootCmd = &cobra.Command{
 // this may be the root command or any of it's children
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/cmd/test_helpers_test.go
+++ b/cmd/test_helpers_test.go
@@ -9,20 +9,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func captureStdout(fn func(cmd *cobra.Command, args []string) error, cmd *cobra.Command, args []string) (string, error) {
+func captureOutput(fn func(cmd *cobra.Command, args []string) error, cmd *cobra.Command, args []string) (string, string, error) {
 	originalStdout := os.Stdout
+	originalStderr := os.Stderr
 
-	var buf bytes.Buffer
-	r, w, _ := os.Pipe()
-	os.Stdout = w
+	var bufOut bytes.Buffer
+	r1, w1, _ := os.Pipe()
+	os.Stdout = w1
+
+	var bufErr bytes.Buffer
+	r2, w2, _ := os.Pipe()
+	os.Stderr = w2
 
 	err := fn(cmd, args)
 
-	w.Close()
+	w1.Close()
 	os.Stdout = originalStdout
-	io.Copy(&buf, r)
+	io.Copy(&bufOut, r1)
 
-	return buf.String(), err
+	w2.Close()
+	os.Stderr = originalStderr
+	io.Copy(&bufErr, r2)
+
+	return bufOut.String(), bufErr.String(), err
 }
 
 func prepareEnvironment() string {


### PR DESCRIPTION
This will simplify editor integrations as we can determine whether or not an action is required by the exit code, meaning we can change the error message without impacting any behaviour.

Additionally, I've updated the `captureStdout` test helper function to also capture stderr since this new functionality will output error messages to stderr.

To maintain more control and improve testability, I've silenced the usage and error message outputted by Cobra in favour of printing error messages myself. The usage message also felt redundant given the minimal number of flags and arguments, and commands.