### PR TITLE
chore: Migrate to `testify/assert`

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -4,26 +4,20 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/aadam-ali/second-brain-cli/config"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVersionCmd(t *testing.T) {
-	var wantError error
-	wantOutput := "sb development\n"
+	wantStdout := "sb development\n"
 
 	gotStdout, _, gotError := captureOutput(versionCmdFunction, versionCmd, []string{})
 
-	if gotError != wantError {
-		t.Errorf("got %q, want %q", gotError, wantError)
-	}
-
-	if gotStdout != wantOutput {
-		t.Errorf("got %q, want %q", gotStdout, wantOutput)
-	}
+	assert.NoError(t, gotError)
+	assert.Equal(t, wantStdout, gotStdout)
 }
 
 func TestNewCmd(t *testing.T) {
@@ -37,54 +31,35 @@ func TestNewCmd(t *testing.T) {
 	os.Create(filepath.Join(sb, "journal/2025-07-13.md"))
 
 	var wantError error
-	wantOutputFilepath := filepath.Join(sb, "inbox/hello-world.md")
+	wantStdoutFilepath := filepath.Join(sb, "inbox/hello-world.md")
 	dontWantOutputDailyNote := fmt.Sprintf("Daily note not found; creating a new one: %s/journal/2025-07-13.md", sb)
 
 	newCmd.Flags().Set("no-open", "true")
 	gotStdout, _, gotError := captureOutput(newCmdFunction, newCmd, []string{"Hello World"})
+	_, newNoteErr := os.Stat(wantStdoutFilepath)
 
-	if gotError != wantError {
-		t.Errorf("got %q, want %q", gotError, wantError)
-	}
-
-	if !strings.Contains(gotStdout, wantOutputFilepath) {
-		t.Errorf("expected to find %q in %q", wantOutputFilepath, gotStdout)
-	}
-
-	if strings.Contains(gotStdout, dontWantOutputDailyNote) {
-		t.Errorf("expected to not find %q in %q", dontWantOutputDailyNote, gotStdout)
-	}
-
-	_, newNoteErr := os.Stat(wantOutputFilepath)
-	if newNoteErr != nil {
-		t.Errorf("expected %q exist", wantOutputFilepath)
-	}
+	assert.Equal(t, wantError, gotError)
+	assert.Contains(t, gotStdout, wantStdoutFilepath)
+	assert.NotContains(t, gotStdout, dontWantOutputDailyNote)
+	assert.NoError(t, newNoteErr)
 }
 
 func TestNewCmdExistingNote(t *testing.T) {
 	sb := prepareEnvironment()
 	defer os.RemoveAll(sb)
 
-	wantOutputFilepath := filepath.Join(sb, "inbox/hello-world.md")
-	wantOutput := fmt.Sprintf("Note with title \"hello-world\" already exists at %s", wantOutputFilepath)
+	wantStdoutFilepath := filepath.Join(sb, "inbox/hello-world.md")
+	wantStderr := fmt.Sprintf("Note with title \"hello-world\" already exists at %s", wantStdoutFilepath)
 
-	os.Create(wantOutputFilepath)
+	os.Create(wantStdoutFilepath)
 
 	newCmd.Flags().Set("no-open", "true")
 	_, gotStderr, gotError := captureOutput(newCmdFunction, newCmd, []string{"Hello World"})
+	_, newNoteErr := os.Stat(wantStdoutFilepath)
 
-	if gotError.Error() != wantOutput {
-		t.Errorf("got %q, want %q", gotError, wantOutput)
-	}
-
-	if !strings.Contains(gotStderr, wantOutput) {
-		t.Errorf("expected to find %q in %q", wantOutput, gotStderr)
-	}
-
-	_, newNoteErr := os.Stat(wantOutputFilepath)
-	if newNoteErr != nil {
-		t.Errorf("expected %q exist", wantOutputFilepath)
-	}
+	assert.Contains(t, gotStderr, wantStderr)
+	assert.NoError(t, newNoteErr)
+	assert.ErrorContains(t, gotError, wantStderr)
 }
 
 func TestNewCmdCreateDailyNote(t *testing.T) {
@@ -95,34 +70,19 @@ func TestNewCmdCreateDailyNote(t *testing.T) {
 	sb := prepareEnvironment()
 	defer os.RemoveAll(sb)
 
-	var wantError error
-	wantOutputFilepath := filepath.Join(sb, "inbox/hello-world.md")
-	wantOutputDailyNote := fmt.Sprintf("Daily note not found; creating a new one: %s/journal/2025-07-13.md", sb)
+	wantStdoutFilepath := filepath.Join(sb, "inbox/hello-world.md")
+	wantStdoutDailyNote := fmt.Sprintf("Daily note not found; creating a new one: %s/journal/2025-07-13.md", sb)
 
 	newCmd.Flags().Set("no-open", "true")
 	gotStdout, _, gotError := captureOutput(newCmdFunction, newCmd, []string{"Hello World"})
-
-	if gotError != wantError {
-		t.Errorf("got %q, want %q", gotError, wantError)
-	}
-
-	if !strings.Contains(gotStdout, wantOutputFilepath) {
-		t.Errorf("expected to find %q in %q", wantOutputFilepath, gotStdout)
-	}
-
-	if !strings.Contains(gotStdout, wantOutputDailyNote) {
-		t.Errorf("expected to find %q in %q", wantOutputDailyNote, gotStdout)
-	}
-
-	_, newNoteErr := os.Stat(wantOutputFilepath)
-	if newNoteErr != nil {
-		t.Errorf("expected %q exist", wantOutputFilepath)
-	}
-
+	_, newNoteErr := os.Stat(wantStdoutFilepath)
 	_, dailyNoteErr := os.Stat(fmt.Sprintf("%s/journal/2025-07-13.md", sb))
-	if dailyNoteErr != nil {
-		t.Errorf("expected %q to exist", wantOutputFilepath)
-	}
+
+	assert.Contains(t, gotStdout, wantStdoutFilepath)
+	assert.Contains(t, gotStdout, wantStdoutDailyNote)
+	assert.NoError(t, gotError)
+	assert.NoError(t, newNoteErr)
+	assert.NoError(t, dailyNoteErr)
 }
 
 func TestDailyCmd(t *testing.T) {
@@ -133,19 +93,14 @@ func TestDailyCmd(t *testing.T) {
 	sb := prepareEnvironment()
 	defer os.RemoveAll(sb)
 
-	var wantError error
-	wantOutputFilepath := filepath.Join(sb, "journal/2025-07-13.md")
+	wantStdoutFilepath := filepath.Join(sb, "journal/2025-07-13.md")
 	dailyCmd.Flags().Set("no-open", "true")
-	_, _, gotError := captureOutput(dailyCmdFunction, dailyCmd, []string{})
-
-	if gotError != wantError {
-		t.Errorf("got %q, want %q", gotError, wantError)
-	}
-
+	gotStdout, _, gotError := captureOutput(dailyCmdFunction, dailyCmd, []string{})
 	_, dailyNoteErr := os.Stat(fmt.Sprintf("%s/journal/2025-07-13.md", sb))
-	if dailyNoteErr != nil {
-		t.Errorf("expected %q to exist", wantOutputFilepath)
-	}
+
+	assert.Contains(t, gotStdout, wantStdoutFilepath)
+	assert.NoError(t, gotError)
+	assert.NoError(t, dailyNoteErr)
 }
 
 func TestDailyCmdAlreadyExists(t *testing.T) {
@@ -156,70 +111,44 @@ func TestDailyCmdAlreadyExists(t *testing.T) {
 	sb := prepareEnvironment()
 	defer os.RemoveAll(sb)
 
-	var wantError error
-	wantOutputFilepath := filepath.Join(sb, "journal/2025-07-13.md")
-	os.Create(wantOutputFilepath)
+	wantStdoutFilepath := filepath.Join(sb, "journal/2025-07-13.md")
+	os.Create(wantStdoutFilepath)
 
 	dailyCmd.Flags().Set("no-open", "true")
 	gotStdout, _, gotError := captureOutput(dailyCmdFunction, dailyCmd, []string{})
-
-	if gotError != wantError {
-		t.Errorf("got %q, want %q", gotError, wantError)
-	}
-
-	if !strings.Contains(gotStdout, wantOutputFilepath) {
-		t.Errorf("expected to find %q in %q", wantOutputFilepath, gotStdout)
-	}
-
 	_, dailyNoteErr := os.Stat(fmt.Sprintf("%s/journal/2025-07-13.md", sb))
-	if dailyNoteErr != nil {
-		t.Errorf("expected %q to exist", wantOutputFilepath)
-	}
+
+	assert.Contains(t, gotStdout, wantStdoutFilepath)
+	assert.NoError(t, gotError)
+	assert.NoError(t, dailyNoteErr)
 }
 
 func TestPathCmdExists(t *testing.T) {
 	sb := prepareEnvironment()
 	defer os.RemoveAll(sb)
 
-	var wantError error
-	wantOutputFilepath := filepath.Join(sb, "inbox/hello-world.md")
-	os.Create(wantOutputFilepath)
+	wantStdoutFilepath := filepath.Join(sb, "inbox/hello-world.md")
+	os.Create(wantStdoutFilepath)
 
 	gotStdout, _, gotError := captureOutput(pathCmdFunction, pathCmd, []string{"hello-world"})
+	_, statErr := os.Stat(wantStdoutFilepath)
 
-	if gotError != wantError {
-		t.Errorf("got %q, want %q", gotError, wantError)
-	}
-
-	if !strings.Contains(gotStdout, wantOutputFilepath) {
-		t.Errorf("expected to find %q in %q", wantOutputFilepath, gotStdout)
-	}
-
-	_, statErr := os.Stat(wantOutputFilepath)
-	if statErr != nil {
-		t.Errorf("expected %q to exist", wantOutputFilepath)
-	}
+	assert.Contains(t, gotStdout, wantStdoutFilepath)
+	assert.NoError(t, gotError)
+	assert.NoError(t, statErr)
 }
 
 func TestPathCmdDoesNotExist(t *testing.T) {
 	sb := prepareEnvironment()
 	defer os.RemoveAll(sb)
 
-	wantOutputFilepath := filepath.Join(sb, "somefolder/hello-world.md")
+	wantStdoutFilepath := filepath.Join(sb, "somefolder/hello-world.md")
 	wantStderr := "Note with title \"hello-world\" (hello-world) does not exist"
 
 	_, gotStderr, gotError := captureOutput(pathCmdFunction, pathCmd, []string{"hello-world"})
+	_, statErr := os.Stat(wantStdoutFilepath)
 
-	if gotError.Error() != wantStderr {
-		t.Errorf("got %q, want %q", gotError, wantStderr)
-	}
-
-	if !strings.Contains(gotStderr, wantStderr) {
-		t.Errorf("expected to not find %q in %q", wantStderr, gotStderr)
-	}
-
-	_, statErr := os.Stat(wantOutputFilepath)
-	if statErr == nil {
-		t.Errorf("expected %q not to exist", wantOutputFilepath)
-	}
+	assert.Contains(t, gotStderr, wantStderr)
+	assert.Error(t, statErr)
+	assert.ErrorContains(t, gotError, wantStderr)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetEnvExists(t *testing.T) {
@@ -13,9 +15,7 @@ func TestGetEnvExists(t *testing.T) {
 
 	got := getEnv("SB_TEST_VAR", "default")
 
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestGetEnvDoesNotExist(t *testing.T) {
@@ -25,9 +25,7 @@ func TestGetEnvDoesNotExist(t *testing.T) {
 
 	got := getEnv("SB_TEST_VAR", want)
 
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestGetConfigDefaultValues(t *testing.T) {
@@ -51,9 +49,7 @@ func TestGetConfigDefaultValues(t *testing.T) {
 	}
 	got := GetConfig()
 
-	if got != want {
-		t.Errorf("got %+v, want %+v", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestGetConfigOverriddenValues(t *testing.T) {
@@ -84,7 +80,5 @@ func TestGetConfigOverriddenValues(t *testing.T) {
 
 	got := GetConfig()
 
-	if got != want {
-		t.Errorf("got %+v, want %+v", got, want)
-	}
+	assert.Equal(t, want, got)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,10 @@ go 1.23.1
 require github.com/spf13/cobra v1.8.1
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,17 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTitleToKebabCase(t *testing.T) {
@@ -27,10 +29,7 @@ func TestTitleToKebabCase(t *testing.T) {
 	for _, tt := range testCases {
 		got := TitleToKebabCase(tt.input)
 
-		if got != tt.want {
-			t.Errorf("got %q, want %q", got, tt.want)
-		}
-
+		assert.Equal(t, tt.want, got)
 	}
 }
 
@@ -47,10 +46,7 @@ func TestConstructNotePath(t *testing.T) {
 	for _, tt := range testCases {
 		got := ConstructNotePath(tt.path, tt.title)
 
-		if got != tt.want {
-			t.Errorf("got %q, want %q", got, tt.want)
-		}
-
+		assert.Equal(t, tt.want, got)
 	}
 }
 
@@ -78,10 +74,7 @@ Some content
 
 		os.RemoveAll(path)
 
-		if string(got) != tt.content {
-			t.Errorf("got %q, want %q", got, tt.content)
-		}
-
+		assert.Equal(t, tt.content, string(got))
 	}
 }
 
@@ -96,10 +89,7 @@ func TestCheckIfNoteExistsReturnPathWhenExists(t *testing.T) {
 
 		_, got := CheckIfNoteExists(rootDir, title)
 
-		if got != want {
-			t.Errorf("got %q, want %q", got, want)
-		}
-
+		assert.Equal(t, want, got)
 	}
 }
 
@@ -109,9 +99,7 @@ func TestCheckIfNoteExistsReturnsEmptyStringWhenNotExists(t *testing.T) {
 
 	_, got := CheckIfNoteExists(rootDir, "but-this-one-does-not")
 
-	if got != "" {
-		t.Errorf("got %q, want %q", got, "")
-	}
+	assert.Empty(t, got)
 }
 
 func TestCheckIfNoteExistsReturnsBool(t *testing.T) {
@@ -135,8 +123,6 @@ func TestCheckIfNoteExistsReturnsBool(t *testing.T) {
 
 		got, _ := CheckIfNoteExists(rootDir, tt.expectedTitle)
 
-		if got != tt.want {
-			t.Errorf("got %t, want %t", got, tt.want)
-		}
+		assert.Equal(t, tt.want, got)
 	}
 }


### PR DESCRIPTION
This makes the tests easier to read, plus removes the duplicated code for carrying out assertions.