### PR TITLE
chore: Use forked version of `go-release-action`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: wangyoucao577/go-release-action@8dbc9990292b456ae78e728c7cf7b857b821faac
+    - uses: aadam-ali/go-release-action@62026c9f20e38c208e44b24d9d511d424149aea9
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}


### PR DESCRIPTION
The original repository still refers to Debian buster, which is no longer maintained and fails to resolve the `deb.debian.org` package repository. However, bullseye is still supported, but there are two more LTS releases after it.