### PR TITLE
feat: Add link command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Run tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v5
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.23'
+
+    - name: Install dependencies
+      run: go mod tidy
+
+    - name: Run tests
+      run: go test -v ./...

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aadam-ali/second-brain-cli/internal"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(linkCmd)
+
+	linkCmd.Flags().BoolP("wiki", "w", false, "returns a wikilink when set to true")
+}
+
+func linkCmdFunction(cmd *cobra.Command, args []string) error {
+	src := args[0]
+	dest := args[1]
+
+	destTitle, _ := strings.CutSuffix(filepath.Base(dest), ".md")
+
+	if _, err := os.Stat(dest); err != nil {
+		return internal.GetError(err.Error())
+	}
+
+	if _, err := os.Stat(src); err != nil {
+		return internal.GetError(err.Error())
+	}
+
+	relpath, err := filepath.Rel(filepath.Dir(src), dest)
+
+	if err != nil {
+		return internal.GetError(err.Error())
+	}
+
+	if useWikiLink, _ := cmd.Flags().GetBool("wiki"); useWikiLink {
+		fmt.Printf("[[%s]]", destTitle)
+	} else {
+		fmt.Printf("[%s](%s)", destTitle, relpath)
+	}
+
+	return nil
+}
+
+var linkCmd = &cobra.Command{
+	Use:   "link [src] [dest]",
+	Short: "Display a link from src to dest",
+	Args:  cobra.MatchAll(cobra.ExactArgs(2)),
+	RunE:  linkCmdFunction,
+}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
-	"os"
 
 	"github.com/aadam-ali/second-brain-cli/config"
 	"github.com/aadam-ali/second-brain-cli/internal"
@@ -35,9 +33,7 @@ func newCmdFunction(cmd *cobra.Command, args []string) error {
 
 		fmt.Println(filepath)
 	} else {
-		error := fmt.Sprintf("Note with title %q already exists at %s", kebabCaseTitle, existingNoteFilepath)
-		fmt.Fprintln(os.Stderr, error)
-		return errors.New(error)
+		return internal.GetError("Note with title %q already exists at %s", kebabCaseTitle, existingNoteFilepath)
 	}
 
 	if !noOpen {

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
-	"os"
 
 	"github.com/aadam-ali/second-brain-cli/config"
 	"github.com/aadam-ali/second-brain-cli/internal"
@@ -23,9 +21,7 @@ func pathCmdFunction(cmd *cobra.Command, args []string) error {
 	noteExists, filepath := internal.CheckIfNoteExists(cfg.RootDir, title)
 
 	if !noteExists {
-		error := fmt.Sprintf("Note with title %q (%s) does not exist", args[0], title)
-		fmt.Fprintln(os.Stderr, error)
-		return errors.New(error)
+		return internal.GetError("Note with title %q (%s) does not exist", args[0], title)
 	}
 
 	fmt.Println(filepath)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"log"
@@ -66,4 +67,10 @@ func OpenFileInVim(rootDir string, filepath string) {
 	if err != nil {
 		fmt.Println(err)
 	}
+}
+
+func GetError(template string, a ...any) error {
+	error := fmt.Sprintf(template, a...)
+	fmt.Fprintln(os.Stderr, error)
+	return errors.New(error)
 }

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -126,3 +126,17 @@ func TestCheckIfNoteExistsReturnsBool(t *testing.T) {
 		assert.Equal(t, tt.want, got)
 	}
 }
+
+func TestGetErrorNoArgs(t *testing.T) {
+	got := GetError("Hi")
+
+	assert.Error(t, got)
+	assert.ErrorContains(t, got, "Hi")
+}
+
+func TestGetErrorWithArgs(t *testing.T) {
+	got := GetError("This is a %s test", "passing")
+
+	assert.Error(t, got)
+	assert.ErrorContains(t, got, "This is a passing test")
+}


### PR DESCRIPTION
The `sb link` command allows the user to pass in a source (path) and destination note (filename), displaying a relative markdown link unless `-w / --wiki` is specified in which case a Wiki Link is displayed.

The intention of this command is to be used by editor integrations to insert a link in the current note.

Also, added a GH Action to run tests on PRs to main, and on merge (or commit) to main.