### PR TITLE
fix: Always only return the path of the daily note

### DIFF
--- a/cmd/daily.go
+++ b/cmd/daily.go
@@ -27,11 +27,9 @@ func dailyCmdFunction(cmd *cobra.Command, args []string) error {
 	if !dailyNoteExists {
 		content := renderDailyNoteContent(cfg.Yesterday, cfg.Today, cfg.Tomorrow)
 		internal.CreateNote(filepath, content)
-
-		fmt.Println(filepath)
-	} else {
-		fmt.Printf("Note already exists: %s\n", filepath)
 	}
+
+	fmt.Println(filepath)
 
 	if !noOpen {
 		internal.OpenFileInVim(cfg.RootDir, cfg.DailyNotePath)


### PR DESCRIPTION
When calling `sb daily` is successful, it should alway return the path of the note only.

There is no value in knowing whether it exists, and makes integrating the command with an editor like Neovim require extra steps to strip out anything that isn't the path of the file.