### PR TITLE
feat: Updated daily command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,4 @@ repos:
     rev: v0.8.3
     hooks:
       - id: go-imports
+      - id: go-test-repo-mod

--- a/cmd/daily.go
+++ b/cmd/daily.go
@@ -2,89 +2,31 @@ package cmd
 
 import (
 	"fmt"
-	"log"
-	"os"
 
 	"github.com/aadam-ali/second-brain-cli/config"
-	"github.com/aadam-ali/second-brain-cli/internal"
 	"github.com/spf13/cobra"
 )
 
 func init() {
 	rootCmd.AddCommand(dailyCmd)
-
-	dailyCmd.Flags().BoolP("no-open", "n", false, "prevents opening of file in editor")
 }
 
 func dailyCmdFunction(cmd *cobra.Command, args []string) error {
 	cfg := config.GetConfig()
 
-	noOpen, _ := cmd.Flags().GetBool("no-open")
-	filepath := cfg.DailyNotePath
+	fmt.Printf(`### %s %s
+@ <location>
 
-	dailyNoteExists := checkIfDailyNoteExists(filepath)
-
-	if !dailyNoteExists {
-		content := renderDailyNoteContent(cfg.Yesterday, cfg.Today, cfg.Tomorrow)
-		internal.CreateNote(filepath, content)
-	}
-
-	fmt.Println(filepath)
-
-	if !noOpen {
-		internal.OpenFileInVim(cfg.RootDir, cfg.DailyNotePath)
-	}
+- todo:
+---
+`, cfg.Today, cfg.DayOfWeek)
 
 	return nil
 }
 
 var dailyCmd = &cobra.Command{
 	Use:   "daily",
-	Short: "create a daily note",
+	Short: "Generate a daily note entry",
 	Args:  cobra.MatchAll(cobra.ExactArgs(0)),
 	RunE:  dailyCmdFunction,
-}
-
-func checkIfDailyNoteExists(filepath string) bool {
-	_, err := os.Stat(filepath)
-
-	if err == nil {
-		return true
-	} else if os.IsNotExist(err) {
-		return false
-	}
-
-	log.Fatal(err)
-
-	return false
-}
-
-func renderDailyNoteContent(yesterday string, today string, tomorrow string) string {
-	return fmt.Sprintf(`# %s
-
-[[%s]] - [[%s]]
-
-## Journal
-
-
-## Notes Created Today
-`, today, yesterday, tomorrow)
-}
-
-func appendToDailyNote(cfg config.Configuration, title string) {
-	if !checkIfDailyNoteExists(cfg.DailyNotePath) {
-		content := renderDailyNoteContent(cfg.Yesterday, cfg.Today, cfg.Tomorrow)
-		internal.CreateNote(cfg.DailyNotePath, content)
-		fmt.Printf("Daily note not found; creating a new one: %s\n", cfg.DailyNotePath)
-	}
-
-	f, err := os.OpenFile(cfg.DailyNotePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer f.Close()
-
-	if _, err := f.WriteString(fmt.Sprintf("\n[[%s]]", title)); err != nil {
-		log.Fatal(err)
-	}
 }

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -29,7 +29,6 @@ func newCmdFunction(cmd *cobra.Command, args []string) error {
 		filepath = internal.ConstructNotePath(cfg.InboxDir, kebabCaseTitle)
 		content := renderStdNoteContent(title)
 		internal.CreateNote(filepath, content)
-		appendToDailyNote(cfg, kebabCaseTitle)
 
 		fmt.Println(filepath)
 	} else {

--- a/config/config.go
+++ b/config/config.go
@@ -15,9 +15,8 @@ type Configuration struct {
 	InboxDir      string
 	JournalDir    string
 	DailyNotePath string
-	Yesterday     string
+	DayOfWeek     string
 	Today         string
-	Tomorrow      string
 	Version       string
 }
 
@@ -30,9 +29,8 @@ func GetConfig() Configuration {
 	inboxDir := getEnv("SB_INBOX", fmt.Sprintf("%s/inbox", rootDir))
 	journalDir := getEnv("SB_JOURNAL", fmt.Sprintf("%s/journal", rootDir))
 
-	yesterday := Now().Add(-24 * time.Hour).Format("2006-01-02")
 	today := Now().Format("2006-01-02")
-	tomorrow := Now().Add(24 * time.Hour).Format("2006-01-02")
+	dayOfWeek := Now().Weekday().String()
 	dailyNotePath := fmt.Sprintf("%s/%s.md", journalDir, today)
 
 	return Configuration{
@@ -40,9 +38,8 @@ func GetConfig() Configuration {
 		InboxDir:      inboxDir,
 		JournalDir:    journalDir,
 		DailyNotePath: dailyNotePath,
-		Yesterday:     yesterday,
+		DayOfWeek:     dayOfWeek,
 		Today:         today,
-		Tomorrow:      tomorrow,
 		Version:       version,
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -42,9 +42,8 @@ func TestGetConfigDefaultValues(t *testing.T) {
 		InboxDir:      rootDir + "/inbox",
 		JournalDir:    rootDir + "/journal",
 		DailyNotePath: rootDir + "/journal/2025-07-13.md",
-		Yesterday:     "2025-07-12",
+		DayOfWeek:     "Sunday",
 		Today:         "2025-07-13",
-		Tomorrow:      "2025-07-14",
 		Version:       "development",
 	}
 	got := GetConfig()
@@ -72,9 +71,8 @@ func TestGetConfigOverriddenValues(t *testing.T) {
 		InboxDir:      sbInbox,
 		JournalDir:    sbJournal,
 		DailyNotePath: sbJournal + "/2025-07-13.md",
-		Yesterday:     "2025-07-12",
+		DayOfWeek:     "Sunday",
 		Today:         "2025-07-13",
-		Tomorrow:      "2025-07-14",
 		Version:       "development",
 	}
 


### PR DESCRIPTION
This is part of a change of approach to the daily note. Rather than a new note for each day, the idea is to have a single `daily.md`, or grouped daily notes (e.g. per month or per year).

Instead of generating a note, the command now outputs an entry for a daily note (in Neovim [or Vim] you can create keybind for `G:r!sb daily<CR>` to add an entry to the end of the file)