### PR TITLE
feat: Improved linking behaviour

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -104,6 +104,29 @@ func TestPathCmdExists(t *testing.T) {
 	}
 }
 
+func TestPathCmdWikiLink(t *testing.T) {
+	var testCases = []string{
+		"hello-world",
+		"hello world",
+	}
+
+	for _, tt := range testCases {
+		sb := prepareEnvironment()
+		defer os.RemoveAll(sb)
+
+		wantStdoutFilepath := filepath.Join(sb, tt+".md")
+		os.Create(wantStdoutFilepath)
+
+		pathCmd.Flags().Set("wiki", "true")
+		gotStdout, _, gotError := captureOutput(pathCmdFunction, pathCmd, []string{tt})
+		_, statErr := os.Stat(wantStdoutFilepath)
+
+		assert.Contains(t, gotStdout, wantStdoutFilepath)
+		assert.NoError(t, gotError)
+		assert.NoError(t, statErr)
+	}
+}
+
 func TestPathCmdDoesNotExist(t *testing.T) {
 	var testCases = []struct {
 		filepathOutput string
@@ -121,6 +144,29 @@ func TestPathCmdDoesNotExist(t *testing.T) {
 		wantStderr := fmt.Sprintf("Note with title \"%[1]s\" (%[1]s) does not exist", tt.filenameInput)
 
 		_, gotStderr, gotError := captureOutput(pathCmdFunction, pathCmd, []string{tt.filenameInput})
+		_, statErr := os.Stat(wantStdoutFilepath)
+
+		assert.Contains(t, gotStderr, wantStderr)
+		assert.Error(t, statErr)
+		assert.ErrorContains(t, gotError, wantStderr)
+	}
+}
+
+func TestPathCmdDoesNotExistWikiLink(t *testing.T) {
+	var testCases = []string{
+		"hello-world",
+		"hello world",
+	}
+
+	for _, tt := range testCases {
+		sb := prepareEnvironment()
+		defer os.RemoveAll(sb)
+
+		wantStdoutFilepath := filepath.Join(sb, tt+".md")
+		wantStderr := fmt.Sprintf("Note with title \"%[1]s\" (%[1]s) does not exist", tt)
+
+		pathCmd.Flags().Set("wiki", "true")
+		_, gotStderr, gotError := captureOutput(pathCmdFunction, pathCmd, []string{tt})
 		_, statErr := os.Stat(wantStdoutFilepath)
 
 		assert.Contains(t, gotStderr, wantStderr)

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -79,86 +79,105 @@ func TestDailyCmd(t *testing.T) {
 }
 
 func TestPathCmdExists(t *testing.T) {
-	sb := prepareEnvironment()
-	defer os.RemoveAll(sb)
+	var testCases = []struct {
+		filepathOutput string
+		filenameInput  string
+	}{
+		{"inbox/hello-world.md", "hello-world.md"},
+		{"inbox/hello world.md", "hello%20world.md"},
+	}
 
-	wantStdoutFilepath := filepath.Join(sb, "inbox/hello-world.md")
-	os.Create(wantStdoutFilepath)
+	for _, tt := range testCases {
+		sb := prepareEnvironment()
+		defer os.RemoveAll(sb)
 
-	gotStdout, _, gotError := captureOutput(pathCmdFunction, pathCmd, []string{"hello-world"})
-	_, statErr := os.Stat(wantStdoutFilepath)
+		wantStdoutFilepath := filepath.Join(sb, tt.filepathOutput)
+		os.Create(wantStdoutFilepath)
 
-	assert.Contains(t, gotStdout, wantStdoutFilepath)
-	assert.NoError(t, gotError)
-	assert.NoError(t, statErr)
+		gotStdout, _, gotError := captureOutput(pathCmdFunction, pathCmd, []string{tt.filenameInput})
+		_, statErr := os.Stat(wantStdoutFilepath)
+
+		assert.Contains(t, gotStdout, wantStdoutFilepath)
+		assert.NoError(t, gotError)
+		assert.NoError(t, statErr)
+
+	}
 }
 
 func TestPathCmdDoesNotExist(t *testing.T) {
-	sb := prepareEnvironment()
-	defer os.RemoveAll(sb)
+	var testCases = []struct {
+		filepathOutput string
+		filenameInput  string
+	}{
+		{"inbox/hello-world.md", "hello-world.md"},
+		{"inbox/hello world.md", "hello%20world.md"},
+	}
 
-	wantStdoutFilepath := filepath.Join(sb, "somefolder/hello-world.md")
-	wantStderr := "Note with title \"hello-world\" (hello-world) does not exist"
+	for _, tt := range testCases {
+		sb := prepareEnvironment()
+		defer os.RemoveAll(sb)
 
-	_, gotStderr, gotError := captureOutput(pathCmdFunction, pathCmd, []string{"hello-world"})
-	_, statErr := os.Stat(wantStdoutFilepath)
+		wantStdoutFilepath := filepath.Join(sb, tt.filepathOutput)
+		wantStderr := fmt.Sprintf("Note with title \"%[1]s\" (%[1]s) does not exist", tt.filenameInput)
 
-	assert.Contains(t, gotStderr, wantStderr)
-	assert.Error(t, statErr)
-	assert.ErrorContains(t, gotError, wantStderr)
+		_, gotStderr, gotError := captureOutput(pathCmdFunction, pathCmd, []string{tt.filenameInput})
+		_, statErr := os.Stat(wantStdoutFilepath)
+
+		assert.Contains(t, gotStderr, wantStderr)
+		assert.Error(t, statErr)
+		assert.ErrorContains(t, gotError, wantStderr)
+	}
 }
 
 func TestLinkCmd(t *testing.T) {
-	sb := prepareEnvironment()
-	defer os.RemoveAll(sb)
+	var testCases = []struct {
+		destFilenameWithoutExtension string
+		urlEncodedDestFilename       string
+	}{
+		{"bonjour-world", "bonjour-world.md"},
+		{"bonjour world", "bonjour%20world.md"},
+	}
 
-	src := filepath.Join(sb, "journal/2025-07-13.md")
-	dest := filepath.Join(sb, "inbox", "hello-world.md")
+	for _, tt := range testCases {
+		sb := prepareEnvironment()
+		defer os.RemoveAll(sb)
 
-	os.Create(src)
-	os.Create(dest)
+		src := filepath.Join(sb, "inbox", "hello-world.md")
+		dest := filepath.Join(sb, "journal", tt.destFilenameWithoutExtension+".md")
 
-	wantOutput := "[hello-world](../inbox/hello-world.md)"
+		os.Create(src)
+		os.Create(dest)
 
-	gotOutput, _, gotError := captureOutput(linkCmdFunction, newCmd, []string{src, dest})
+		wantOutput := fmt.Sprintf("[%s](../journal/%s)", tt.destFilenameWithoutExtension, tt.urlEncodedDestFilename)
+		gotOutput, _, gotError := captureOutput(linkCmdFunction, newCmd, []string{src, dest})
 
-	assert.NoError(t, gotError)
-	assert.Equal(t, wantOutput, gotOutput)
+		assert.NoError(t, gotError)
+		assert.Equal(t, wantOutput, gotOutput)
+	}
 }
 
 func TestLinkCmdWikiLink(t *testing.T) {
-	sb := prepareEnvironment()
-	defer os.RemoveAll(sb)
+	var testCases = []string{
+		"bonjour-world",
+		"bonjour world",
+	}
 
-	src := filepath.Join(sb, "journal/2025-07-13.md")
-	dest := filepath.Join(sb, "inbox", "hello-world.md")
+	for _, tt := range testCases {
+		sb := prepareEnvironment()
+		defer os.RemoveAll(sb)
 
-	os.Create(src)
-	os.Create(dest)
+		src := filepath.Join(sb, "inbox", "hello-world.md")
+		dest := filepath.Join(sb, "journal", tt+".md")
 
-	wantOutput := "[[hello-world]]"
+		os.Create(src)
+		os.Create(dest)
 
-	linkCmd.Flags().Set("wiki", "true")
-	gotOutput, _, gotError := captureOutput(linkCmdFunction, linkCmd, []string{src, dest})
+		wantOutput := fmt.Sprintf("[[%s]]", tt)
 
-	assert.NoError(t, gotError)
-	assert.Equal(t, wantOutput, gotOutput)
-}
+		linkCmd.Flags().Set("wiki", "true")
+		gotOutput, _, gotError := captureOutput(linkCmdFunction, linkCmd, []string{src, dest})
 
-func TestLinkCmdDestNotExist(t *testing.T) {
-	sb := prepareEnvironment()
-	os.RemoveAll(sb)
-
-	src := filepath.Join(sb, "journal/2025-07-13.md")
-	dest := filepath.Join(sb, "hello-world.md")
-
-	os.Create(src)
-
-	wantError := fmt.Sprintf("stat %s: no such file or directory", dest)
-
-	_, gotStderr, gotError := captureOutput(linkCmdFunction, linkCmd, []string{src, dest})
-
-	assert.Contains(t, gotStderr, wantError)
-	assert.Error(t, gotError)
-	assert.ErrorContains(t, gotError, wantError)
+		assert.NoError(t, gotError)
+		assert.Equal(t, wantOutput, gotOutput)
+	}
 }

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -23,7 +23,7 @@ func newCmdFunction(cmd *cobra.Command, args []string) error {
 
 	kebabCaseTitle := internal.TitleToKebabCase(title)
 
-	noteExists, existingNoteFilepath := internal.CheckIfNoteExists(cfg.RootDir, kebabCaseTitle)
+	noteExists, existingNoteFilepath := internal.CheckIfNoteExists(cfg.RootDir, kebabCaseTitle+".md")
 
 	if !noteExists {
 		filepath = internal.ConstructNotePath(cfg.InboxDir, kebabCaseTitle)

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -11,6 +11,8 @@ import (
 
 func init() {
 	rootCmd.AddCommand(pathCmd)
+
+	pathCmd.Flags().BoolP("wiki", "w", false, "assumes the filename is from a wikilink")
 }
 
 func pathCmdFunction(cmd *cobra.Command, args []string) error {
@@ -18,6 +20,10 @@ func pathCmdFunction(cmd *cobra.Command, args []string) error {
 	title := args[0]
 
 	urlEscapedTitle, _ := url.PathUnescape(title)
+
+	if isWikiLink, _ := cmd.Flags().GetBool("wiki"); isWikiLink {
+		urlEscapedTitle += ".md"
+	}
 
 	noteExists, filepath := internal.CheckIfNoteExists(cfg.RootDir, urlEscapedTitle)
 

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/aadam-ali/second-brain-cli/config"
 	"github.com/aadam-ali/second-brain-cli/internal"
@@ -16,9 +17,9 @@ func pathCmdFunction(cmd *cobra.Command, args []string) error {
 	cfg := config.GetConfig()
 	title := args[0]
 
-	title = internal.TitleToKebabCase(title)
+	urlEscapedTitle, _ := url.PathUnescape(title)
 
-	noteExists, filepath := internal.CheckIfNoteExists(cfg.RootDir, title)
+	noteExists, filepath := internal.CheckIfNoteExists(cfg.RootDir, urlEscapedTitle)
 
 	if !noteExists {
 		return internal.GetError("Note with title %q (%s) does not exist", args[0], title)
@@ -30,7 +31,7 @@ func pathCmdFunction(cmd *cobra.Command, args []string) error {
 
 var pathCmd = &cobra.Command{
 	Use:   "path [title]",
-	Short: "outputs path of note if it exists",
+	Short: "Output path of note if it exists",
 	Args:  cobra.MatchAll(cobra.ExactArgs(1)),
 	RunE:  pathCmdFunction,
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -21,7 +21,7 @@ func versionCmdFunction(cmd *cobra.Command, args []string) error {
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "outputs version of sb",
+	Short: "Output version of sb",
 	Args:  cobra.MatchAll(cobra.ExactArgs(0)),
 	RunE:  versionCmdFunction,
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -39,7 +39,9 @@ func CreateNote(filepath string, content string) {
 
 func CheckIfNoteExists(rootDir string, name string) (bool, string) {
 	pathToNote := ""
-	name = name + ".md"
+	// if hasExtension := strings.HasSuffix(name, ".md"); hasExtension {
+	// 	name = name + ".md"
+	// }
 
 	err := filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, err error) error {
 		if !d.IsDir() && name == d.Name() {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -39,9 +39,6 @@ func CreateNote(filepath string, content string) {
 
 func CheckIfNoteExists(rootDir string, name string) (bool, string) {
 	pathToNote := ""
-	// if hasExtension := strings.HasSuffix(name, ".md"); hasExtension {
-	// 	name = name + ".md"
-	// }
 
 	err := filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, err error) error {
 		if !d.IsDir() && name == d.Name() {

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -87,7 +87,7 @@ func TestCheckIfNoteExistsReturnPathWhenExists(t *testing.T) {
 		rootDir, _, want := createNoteInTempDir(title, tt)
 		defer os.RemoveAll(rootDir)
 
-		_, got := CheckIfNoteExists(rootDir, title)
+		_, got := CheckIfNoteExists(rootDir, title+".md")
 
 		assert.Equal(t, want, got)
 	}
@@ -97,7 +97,7 @@ func TestCheckIfNoteExistsReturnsEmptyStringWhenNotExists(t *testing.T) {
 	rootDir, _, _ := createNoteInTempDir("this-one-exists", false)
 	defer os.RemoveAll(rootDir)
 
-	_, got := CheckIfNoteExists(rootDir, "but-this-one-does-not")
+	_, got := CheckIfNoteExists(rootDir, "but-this-one-does-not"+".md")
 
 	assert.Empty(t, got)
 }
@@ -121,7 +121,7 @@ func TestCheckIfNoteExistsReturnsBool(t *testing.T) {
 		rootDir, _, _ := createNoteInTempDir(tt.createTitle, tt.nested)
 		defer os.RemoveAll(rootDir)
 
-		got, _ := CheckIfNoteExists(rootDir, tt.expectedTitle)
+		got, _ := CheckIfNoteExists(rootDir, tt.expectedTitle+".md")
 
 		assert.Equal(t, tt.want, got)
 	}


### PR DESCRIPTION
The main change made here, is to URL encode filenames which contains spaces, making the navigation of these notes work as expected when viewing them in GitHub.

The path command has been updated to URL decode the filenames when the input is from a markdown link.

It's key to note that the desired functionality is that the uniqueness of filenames will be case insensitive (to account for filesystems which behave like this - looking at you APFS).

Additionally, the new command will be updated to allow spaces in filenames (in an upcoming PR), as well as some other functionality changes to reduce some of the friction when creating notes across devices.