### PR TITLE
feat: Revised `new` command

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -21,18 +21,18 @@ func newCmdFunction(cmd *cobra.Command, args []string) error {
 	var filepath string
 	title := args[0]
 
-	kebabCaseTitle := internal.TitleToKebabCase(title)
+	sanitisedTitle := internal.SanitiseTitle(title)
 
-	noteExists, existingNoteFilepath := internal.CheckIfNoteExists(cfg.RootDir, kebabCaseTitle+".md")
+	noteExists, existingNoteFilepath := internal.CheckIfNoteExists(cfg.RootDir, sanitisedTitle+".md")
 
 	if !noteExists {
-		filepath = internal.ConstructNotePath(cfg.InboxDir, kebabCaseTitle)
+		filepath = internal.ConstructNotePath(cfg.InboxDir, sanitisedTitle)
 		content := renderStdNoteContent(title)
 		internal.CreateNote(filepath, content)
 
 		fmt.Println(filepath)
 	} else {
-		return internal.GetError("Note with title %q already exists at %s", kebabCaseTitle, existingNoteFilepath)
+		return internal.GetError("Note with title %q already exists at %s", sanitisedTitle, existingNoteFilepath)
 	}
 
 	if !noOpen {

--- a/cmd/path.go
+++ b/cmd/path.go
@@ -19,13 +19,13 @@ func pathCmdFunction(cmd *cobra.Command, args []string) error {
 	cfg := config.GetConfig()
 	title := args[0]
 
-	urlEscapedTitle, _ := url.PathUnescape(title)
+	urlDecodedTitle, _ := url.PathUnescape(title)
 
 	if isWikiLink, _ := cmd.Flags().GetBool("wiki"); isWikiLink {
-		urlEscapedTitle += ".md"
+		urlDecodedTitle += ".md"
 	}
 
-	noteExists, filepath := internal.CheckIfNoteExists(cfg.RootDir, urlEscapedTitle)
+	noteExists, filepath := internal.CheckIfNoteExists(cfg.RootDir, urlDecodedTitle)
 
 	if !noteExists {
 		return internal.GetError("Note with title %q (%s) does not exist", args[0], title)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -12,13 +12,12 @@ import (
 	"strings"
 )
 
-func TitleToKebabCase(title string) string {
-	title = strings.ToLower(title)
+func SanitiseTitle(title string) string {
+	alphanumericTitle := regexp.MustCompile(`[^A-Za-z0-9-_]+`).ReplaceAllString(title, " ")
+	squashedWhitespaceTitle := regexp.MustCompile(`\s+`).ReplaceAllString(alphanumericTitle, " ")
+	sanitisedTitle := regexp.MustCompile(`^[-_\s]+|[-_\s]+$`).ReplaceAllString(squashedWhitespaceTitle, "")
 
-	title = regexp.MustCompile(`[^a-z0-9]+`).ReplaceAllString(title, "-")
-	title = regexp.MustCompile(`^-+|-+$`).ReplaceAllString(title, "")
-
-	return title
+	return sanitisedTitle
 }
 
 func ConstructNotePath(dir string, title string) string {
@@ -41,7 +40,7 @@ func CheckIfNoteExists(rootDir string, name string) (bool, string) {
 	pathToNote := ""
 
 	err := filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, err error) error {
-		if !d.IsDir() && name == d.Name() {
+		if !d.IsDir() && strings.EqualFold(name, d.Name()) {
 			pathToNote = path
 		}
 		return nil

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -8,26 +8,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTitleToKebabCase(t *testing.T) {
+func TestSanitiseTitle(t *testing.T) {
 	var testCases = []struct {
 		input string
 		want  string
 	}{
-		{"lower case only", "lower-case-only"},
-		{"UPPER CASE ONLY", "upper-case-only"},
-		{"Mixed Case", "mixed-case"},
+		{"lower case only", "lower case only"},
+		{"UPPER CASE ONLY", "UPPER CASE ONLY"},
+		{"Mixed Case", "Mixed Case"},
 		{"kebab-case", "kebab-case"},
-		{"squash----hyphens", "squash-hyphens"},
-		{" Leading space", "leading-space"},
-		{"-Leading hyphen", "leading-hyphen"},
-		{"Trailing hyphen-", "trailing-hyphen"},
-		{"1 c4n c0unt 123456789", "1-c4n-c0unt-123456789"},
-		{"h3llo@world!", "h3llo-world"},
-		{"Keyboard special keys `~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/?", "keyboard-special-keys"},
+		{"squash----hyphens", "squash----hyphens"},
+		{" Leading space", "Leading space"},
+		{"-Leading hyphen", "Leading hyphen"},
+		{"Trailing hyphen-", "Trailing hyphen"},
+		{"1 c4n c0unt 123456789", "1 c4n c0unt 123456789"},
+		{"h3llo@world!", "h3llo world"},
+		{"Keyboard special keys `~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/?", "Keyboard special keys"},
 	}
 
 	for _, tt := range testCases {
-		got := TitleToKebabCase(tt.input)
+		got := SanitiseTitle(tt.input)
 
 		assert.Equal(t, tt.want, got)
 	}


### PR DESCRIPTION
The aim of this change is to reduce friction when creating notes, but also offers aesthetic improvements when looking at graph views in Obsidian.

Additionially, it removes the requirement of creating titles which are kebabe cased when creating notes whilst not directly interfacing with the `sb` cli.

The new filename opinions being introduced in this change are:

  - Filenames may contain alphanumeric characters, spaces, hyphens, and underscores
  - Filenames must start and end with an alphanumeric character (excluding the `.md` extension)
  - Filenames should not contain consecutive spaces, hyphens, or underscores
  - Filenames should be unique regardless of casing
    * The existence of `Hello World.md` will prevent the creation of `hello world.md`