### PR TITLE
feat: `--date` flag for new command

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -87,6 +87,36 @@ func TestNewCmdExistingNote(t *testing.T) {
 	}
 }
 
+func TestNewCmdDateFlag(t *testing.T) {
+	var testCases = []struct {
+		inputTitle     string
+		sanitisedTitle string
+	}{
+		{"Hello World", "20250713 Hello World"},
+	}
+
+	for _, tt := range testCases {
+		config.Now = func() time.Time {
+			return time.Date(2025, 7, 13, 20, 0, 0, 0, time.UTC)
+		}
+
+		sb := prepareEnvironment()
+		defer os.RemoveAll(sb)
+
+		var wantError error
+		wantStdoutFilepath := filepath.Join(sb, "inbox", tt.sanitisedTitle+".md")
+
+		newCmd.Flags().Set("no-open", "true")
+		newCmd.Flags().Set("date", "true")
+		gotStdout, _, gotError := captureOutput(newCmdFunction, newCmd, []string{tt.inputTitle})
+		_, newNoteErr := os.Stat(wantStdoutFilepath)
+
+		assert.Equal(t, wantError, gotError)
+		assert.Contains(t, gotStdout, wantStdoutFilepath)
+		assert.NoError(t, newNoteErr)
+	}
+}
+
 func TestDailyCmd(t *testing.T) {
 	config.Now = func() time.Time {
 		return time.Date(2025, 7, 13, 20, 0, 0, 0, time.UTC)

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -12,6 +12,7 @@ func init() {
 	rootCmd.AddCommand(newCmd)
 
 	newCmd.Flags().BoolP("no-open", "n", false, "prevents opening of file in editor")
+	newCmd.Flags().BoolP("date", "d", false, "prepends the date to the filename")
 }
 
 func newCmdFunction(cmd *cobra.Command, args []string) error {
@@ -22,6 +23,10 @@ func newCmdFunction(cmd *cobra.Command, args []string) error {
 	title := args[0]
 
 	sanitisedTitle := internal.SanitiseTitle(title)
+
+	if dateFlag, _ := cmd.Flags().GetBool("date"); dateFlag {
+		sanitisedTitle = config.Now().Format("20060102 ") + sanitisedTitle
+	}
 
 	noteExists, existingNoteFilepath := internal.CheckIfNoteExists(cfg.RootDir, sanitisedTitle+".md")
 


### PR DESCRIPTION
This allows the creation of notes which include the current date in the filename. Whilst, the Zettelkasten method includes providing unique identifiers (usually the current date and time), this isn't as necessary in a digital system where notes can be easily searched. However, there is utility in dating notes where the creation time is key to identifying them.