### PR TITLE
fix: Errors when directories don't exist

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/aadam-ali/second-brain-cli/config"
 	"github.com/spf13/cobra"
 )
 
@@ -26,6 +27,12 @@ var rootCmd = &cobra.Command{
 // Execute handles the execution of the provided command
 // this may be the root command or any of it's children
 func Execute() {
+	cfg := config.GetConfig()
+
+	os.MkdirAll(cfg.RootDir, os.ModePerm)
+	os.MkdirAll(cfg.InboxDir, os.ModePerm)
+	os.MkdirAll(cfg.JournalDir, os.ModePerm)
+
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -25,7 +25,7 @@ type Configuration struct {
 func GetConfig() Configuration {
 	userHomeDir, _ := os.UserHomeDir()
 
-	rootDir := getEnv("SB", fmt.Sprintf("%s/SecondBrain", userHomeDir))
+	rootDir := getEnv("SB", fmt.Sprintf("%s/notes", userHomeDir))
 	inboxDir := getEnv("SB_INBOX", fmt.Sprintf("%s/inbox", rootDir))
 	journalDir := getEnv("SB_JOURNAL", fmt.Sprintf("%s/journal", rootDir))
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -35,7 +35,7 @@ func TestGetConfigDefaultValues(t *testing.T) {
 
 	os.Clearenv()
 	os.Setenv("HOME", "/home/test")
-	rootDir := "/home/test/SecondBrain"
+	rootDir := "/home/test/notes"
 
 	want := Configuration{
 		RootDir:       rootDir,


### PR DESCRIPTION
This commit addresses an issue where the `new` command fails if the directories don't exist beforehand. Improving the user experience when starting a new notes directory, or setting up the tool for the first time.