### PR TITLE
fix: Errors when directories don't exist

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -38,24 +38,28 @@ func TestNewCmd(t *testing.T) {
 		{"Keyboard special keys `~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/?", "Keyboard special keys"},
 	}
 
+	createDirectoriesFlags := []bool{true, false}
+
 	for _, tt := range testCases {
-		config.Now = func() time.Time {
-			return time.Date(2025, 7, 13, 20, 0, 0, 0, time.UTC)
+		for _, createDirectoriesFlag := range createDirectoriesFlags {
+			config.Now = func() time.Time {
+				return time.Date(2025, 7, 13, 20, 0, 0, 0, time.UTC)
+			}
+
+			sb := prepareEnvironment(createDirectoriesFlag)
+			defer os.RemoveAll(sb)
+
+			var wantError error
+			wantStdoutFilepath := filepath.Join(sb, "inbox", "20250713 "+tt.sanitisedTitle+".md")
+
+			newCmd.Flags().Set("no-open", "true")
+			gotStdout, _, gotError := captureOutput(newCmdFunction, newCmd, []string{tt.inputTitle})
+			_, newNoteErr := os.Stat(wantStdoutFilepath)
+
+			assert.Equal(t, wantError, gotError)
+			assert.Contains(t, gotStdout, wantStdoutFilepath)
+			assert.NoError(t, newNoteErr)
 		}
-
-		sb := prepareEnvironment()
-		defer os.RemoveAll(sb)
-
-		var wantError error
-		wantStdoutFilepath := filepath.Join(sb, "inbox", "20250713 "+tt.sanitisedTitle+".md")
-
-		newCmd.Flags().Set("no-open", "true")
-		gotStdout, _, gotError := captureOutput(newCmdFunction, newCmd, []string{tt.inputTitle})
-		_, newNoteErr := os.Stat(wantStdoutFilepath)
-
-		assert.Equal(t, wantError, gotError)
-		assert.Contains(t, gotStdout, wantStdoutFilepath)
-		assert.NoError(t, newNoteErr)
 	}
 }
 
@@ -68,7 +72,7 @@ func TestNewCmdNoDateFlag(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		sb := prepareEnvironment()
+		sb := prepareEnvironment(true)
 		defer os.RemoveAll(sb)
 
 		var wantError error
@@ -99,7 +103,7 @@ func TestNewCmdExistingNote(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		sb := prepareEnvironment()
+		sb := prepareEnvironment(true)
 		defer os.RemoveAll(sb)
 
 		wantStdoutFilepath := filepath.Join(sb, "inbox", "Hello World"+".md")
@@ -145,7 +149,7 @@ func TestPathCmdExists(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		sb := prepareEnvironment()
+		sb := prepareEnvironment(true)
 		defer os.RemoveAll(sb)
 
 		wantStdoutFilepath := filepath.Join(sb, tt.filepathOutput)
@@ -168,7 +172,7 @@ func TestPathCmdWikiLink(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		sb := prepareEnvironment()
+		sb := prepareEnvironment(true)
 		defer os.RemoveAll(sb)
 
 		wantStdoutFilepath := filepath.Join(sb, tt+".md")
@@ -194,7 +198,7 @@ func TestPathCmdDoesNotExist(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		sb := prepareEnvironment()
+		sb := prepareEnvironment(true)
 		defer os.RemoveAll(sb)
 
 		wantStdoutFilepath := filepath.Join(sb, tt.filepathOutput)
@@ -216,7 +220,7 @@ func TestPathCmdDoesNotExistWikiLink(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		sb := prepareEnvironment()
+		sb := prepareEnvironment(true)
 		defer os.RemoveAll(sb)
 
 		wantStdoutFilepath := filepath.Join(sb, tt+".md")
@@ -242,7 +246,7 @@ func TestLinkCmd(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		sb := prepareEnvironment()
+		sb := prepareEnvironment(true)
 		defer os.RemoveAll(sb)
 
 		src := filepath.Join(sb, "inbox", "hello-world.md")
@@ -266,7 +270,7 @@ func TestLinkCmdWikiLink(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		sb := prepareEnvironment()
+		sb := prepareEnvironment(true)
 		defer os.RemoveAll(sb)
 
 		src := filepath.Join(sb, "inbox", "hello-world.md")

--- a/cmd/test_helpers_test.go
+++ b/cmd/test_helpers_test.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -34,10 +36,14 @@ func captureOutput(fn func(cmd *cobra.Command, args []string) error, cmd *cobra.
 	return bufOut.String(), bufErr.String(), err
 }
 
-func prepareEnvironment() string {
-	sb, _ := os.MkdirTemp("", "second-brain-cli-")
-	os.Mkdir(filepath.Join(sb, "inbox"), 0700)
-	os.Mkdir(filepath.Join(sb, "journal"), 0700)
+func prepareEnvironment(createDirectories bool) string {
+	sb := fmt.Sprintf("/tmp/second-brain-cli-%d", time.Now().UnixNano())
+
+	if createDirectories {
+		os.Mkdir(sb, 0700)
+		os.Mkdir(filepath.Join(sb, "inbox"), 0700)
+		os.Mkdir(filepath.Join(sb, "journal"), 0700)
+	}
 
 	os.Clearenv()
 	os.Setenv("SB", sb)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -25,8 +25,12 @@ func ConstructNotePath(dir string, title string) string {
 	return filepath.Join(dir, titleWithExtension)
 }
 
-func CreateNote(filepath string, content string) {
-	f, _ := os.Create(filepath)
+func CreateNote(pathToFile string, content string) {
+	if err := os.MkdirAll(filepath.Dir(pathToFile), 0770); err != nil {
+		return
+	}
+
+	f, _ := os.Create(pathToFile)
 	defer f.Close()
 
 	_, err := f.Write([]byte(content))
@@ -38,6 +42,10 @@ func CreateNote(filepath string, content string) {
 
 func CheckIfNoteExists(rootDir string, name string) (bool, string) {
 	pathToNote := ""
+
+	if _, err := os.Stat(rootDir); err != nil {
+		return false, ""
+	}
 
 	err := filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, err error) error {
 		if !d.IsDir() && strings.EqualFold(name, d.Name()) {

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -1,9 +1,11 @@
 package internal
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -96,6 +98,14 @@ func TestCheckIfNoteExistsReturnPathWhenExists(t *testing.T) {
 func TestCheckIfNoteExistsReturnsEmptyStringWhenNotExists(t *testing.T) {
 	rootDir, _, _ := createNoteInTempDir("this-one-exists", false)
 	defer os.RemoveAll(rootDir)
+
+	_, got := CheckIfNoteExists(rootDir, "but-this-one-does-not"+".md")
+
+	assert.Empty(t, got)
+}
+
+func TestCheckIfNoteExistsReturnsEmptyStringWhenDirNotExists(t *testing.T) {
+	rootDir := fmt.Sprintf("/tmp/this-dir-does-not-exist-%d", time.Now().UnixNano())
 
 	_, got := CheckIfNoteExists(rootDir, "but-this-one-does-not"+".md")
 


### PR DESCRIPTION
This is an undesirable behaviour experienced when using the sb for the first time. This commit fixes the issue by creating the directories required to create a note when the `new` command is invoked.