### PR TITLE
feat: Rename default dir to `notes` from `SecondBrain`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,7 +25,7 @@ type Configuration struct {
 func GetConfig() Configuration {
 	userHomeDir, _ := os.UserHomeDir()
 
-	rootDir := getEnv("SB", fmt.Sprintf("%s/SecondBrain", userHomeDir))
+	rootDir := getEnv("SB", fmt.Sprintf("%s/notes", userHomeDir))
 	inboxDir := getEnv("SB_INBOX", fmt.Sprintf("%s/inbox", rootDir))
 	journalDir := getEnv("SB_JOURNAL", fmt.Sprintf("%s/journal", rootDir))
 

--- a/config/config.go
+++ b/config/config.go
@@ -27,20 +27,16 @@ func GetConfig() Configuration {
 
 	rootDir := getEnv("SB", fmt.Sprintf("%s/notes", userHomeDir))
 	inboxDir := getEnv("SB_INBOX", fmt.Sprintf("%s/inbox", rootDir))
-	journalDir := getEnv("SB_JOURNAL", fmt.Sprintf("%s/journal", rootDir))
 
 	today := Now().Format("2006-01-02")
 	dayOfWeek := Now().Weekday().String()
-	dailyNotePath := fmt.Sprintf("%s/%s.md", journalDir, today)
 
 	return Configuration{
-		RootDir:       rootDir,
-		InboxDir:      inboxDir,
-		JournalDir:    journalDir,
-		DailyNotePath: dailyNotePath,
-		DayOfWeek:     dayOfWeek,
-		Today:         today,
-		Version:       version,
+		RootDir:   rootDir,
+		InboxDir:  inboxDir,
+		DayOfWeek: dayOfWeek,
+		Today:     today,
+		Version:   version,
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -35,7 +35,7 @@ func TestGetConfigDefaultValues(t *testing.T) {
 
 	os.Clearenv()
 	os.Setenv("HOME", "/home/test")
-	rootDir := "/home/test/SecondBrain"
+	rootDir := "/home/test/notes"
 
 	want := Configuration{
 		RootDir:       rootDir,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,13 +38,11 @@ func TestGetConfigDefaultValues(t *testing.T) {
 	rootDir := "/home/test/notes"
 
 	want := Configuration{
-		RootDir:       rootDir,
-		InboxDir:      rootDir + "/inbox",
-		JournalDir:    rootDir + "/journal",
-		DailyNotePath: rootDir + "/journal/2025-07-13.md",
-		DayOfWeek:     "Sunday",
-		Today:         "2025-07-13",
-		Version:       "development",
+		RootDir:   rootDir,
+		InboxDir:  rootDir + "/inbox",
+		DayOfWeek: "Sunday",
+		Today:     "2025-07-13",
+		Version:   "development",
 	}
 	got := GetConfig()
 
@@ -57,23 +55,19 @@ func TestGetConfigOverriddenValues(t *testing.T) {
 	}
 
 	sb := "/home/test/Documents/Notes"
-	sbJournal := "/home/test/Documents/Notes/Log"
 	sbInbox := "/home/test/Documents/Notes/Entrypoint"
 
 	os.Clearenv()
 	os.Setenv("HOME", "/home/test")
 	os.Setenv("SB", sb)
-	os.Setenv("SB_JOURNAL", sbJournal)
 	os.Setenv("SB_INBOX", sbInbox)
 
 	want := Configuration{
-		RootDir:       sb,
-		InboxDir:      sbInbox,
-		JournalDir:    sbJournal,
-		DailyNotePath: sbJournal + "/2025-07-13.md",
-		DayOfWeek:     "Sunday",
-		Today:         "2025-07-13",
-		Version:       "development",
+		RootDir:   sb,
+		InboxDir:  sbInbox,
+		DayOfWeek: "Sunday",
+		Today:     "2025-07-13",
+		Version:   "development",
 	}
 
 	got := GetConfig()


### PR DESCRIPTION
Also removes dead config code related to daily notes. I don't use daily notes, in fact I don't log daily notes digitally. The daily command remains as it _might_ be useful to someone that comes across this repo without requiring much maintenance from me.