### PR TITLE
feat: Use YYYY-MM-DD instead of YYYYMMDD

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -50,7 +50,7 @@ func TestNewCmd(t *testing.T) {
 			defer os.RemoveAll(sb)
 
 			var wantError error
-			wantStdoutFilepath := filepath.Join(sb, "inbox", "20250713 "+tt.sanitisedTitle+".md")
+			wantStdoutFilepath := filepath.Join(sb, "inbox", "2025-07-13 "+tt.sanitisedTitle+".md")
 
 			newCmd.Flags().Set("no-open", "true")
 			gotStdout, _, gotError := captureOutput(newCmdFunction, newCmd, []string{tt.inputTitle})

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -25,14 +25,14 @@ func newCmdFunction(cmd *cobra.Command, args []string) error {
 	sanitisedTitle := internal.SanitiseTitle(title)
 
 	if dateFlag, _ := cmd.Flags().GetBool("no-date"); !dateFlag {
-		sanitisedTitle = config.Now().Format("20060102 ") + sanitisedTitle
+		sanitisedTitle = cfg.Today + " " + sanitisedTitle
 	}
 
 	noteExists, existingNoteFilepath := internal.CheckIfNoteExists(cfg.RootDir, sanitisedTitle+".md")
 
 	if !noteExists {
 		filepath = internal.ConstructNotePath(cfg.InboxDir, sanitisedTitle)
-		content := renderStdNoteContent(title)
+		content := renderStdNoteContent(title, cfg.Today)
 		internal.CreateNote(filepath, content)
 
 		fmt.Println(filepath)
@@ -53,6 +53,6 @@ var newCmd = &cobra.Command{
 	Args:  cobra.MatchAll(cobra.ExactArgs(1)),
 	RunE:  newCmdFunction}
 
-func renderStdNoteContent(title string) string {
-	return fmt.Sprintf("---\ntitle: %s\n---\n", title)
+func renderStdNoteContent(title string, date string) string {
+	return fmt.Sprintf("---\ntitle: %s\ndate: %s\n---\n", title, date)
 }


### PR DESCRIPTION
This improves the at a glance experience when trying to grok through a list of titles.

Also, includes the date when a note is created for use of static site generators.